### PR TITLE
ON-184

### DIFF
--- a/harmonize/data/processed/net_zero_tracker/Publisher.csv
+++ b/harmonize/data/processed/net_zero_tracker/Publisher.csv
@@ -1,2 +1,3 @@
 id,name,URL
 net_zero_tracker,Net Zero Tracker,https://zerotracker.net/
+GLEIF,Global Legal Entity Identifier Foundation,https://www.gleif.org/en

--- a/harmonize/data/processed/net_zero_tracker/Target.csv
+++ b/harmonize/data/processed/net_zero_tracker/Target.csv
@@ -1,769 +1,1560 @@
 target_id,actor_id,target_type,baseline_year,target_year,target_value,target_unit,URL,datasource_id
-net_zero_tracker:AO:2030,AO,Absolute emission reduction,2015,2030,21,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Angola%20First/NDC%20Angola.pdf,net_zero_tracker
-net_zero_tracker:BA:2050,BA,Absolute emission reduction,2014,2050,50,percent,https://www.climatewatchdata.org/ndcs/country/BIH?document=revised_first_ndc,net_zero_tracker
-net_zero_tracker:DM:2030,DM,Absolute emission reduction,2014,2030,45,percent,https://unfccc.int/sites/default/files/2022-07/The%20Commonwealth%20of%20Dominica%20updated%20NDC%20July%204%20%2C.pdf,net_zero_tracker
-net_zero_tracker:GQ:2050,GQ,Absolute emission reduction,2010,2050,50,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Equatorial%20Guinea%20First/Rep%C3%BAblica%20de%20Guinea%20Ecuatorial_INDC.pdf,net_zero_tracker
-net_zero_tracker:KN:2030,KN,Absolute emission reduction,2010,2030,61,percent,https://unfccc.int/sites/default/files/NDC/2022-06/St.%20Kitts%20and%20Nevis%20Revised%20NDC_Updated.pdf,net_zero_tracker
-net_zero_tracker:LC:2030,LC,Relative emission reduction,2030,2030,23,percent,https://unfccc.int/sites/default/files/NDC/2022-06/Saint%20Lucia%20First%20NDC%20%28Updated%20submission%29.pdf,net_zero_tracker
-net_zero_tracker:MK:2030,MK,Absolute emission reduction,1990,2030,82,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/The%20Republic%20of%20North%20Macedonia%20First/Macedonian%20enhanced%20NDC%20(002).pdf,net_zero_tracker
-net_zero_tracker:NL:2050,NL,Absolute emission reduction,1990,2050,95,percent,https://www.cbs.nl/en-gb/news/2022/06/urgenda-reduction-target-for-ghg-emissions-achieved-in-2020,net_zero_tracker
-net_zero_tracker:NO:2050,NO,Absolute emission reduction,1990,2050,95,percent,https://unfccc.int/sites/default/files/NDC/2022-11/NDC%20Norway_second%20update.pdf,net_zero_tracker
-net_zero_tracker:PY:2030,PY,Relative emission reduction,2030,2030,20,percent,http://www.mades.gov.py/wp-content/uploads/2021/07/ACTUALIZACION-DE-LA-NDC-DEL-PARAGUAY_Borrador-final_Julio-2021-1.pdf,net_zero_tracker
-net_zero_tracker:UG:2030,UG,Relative emission reduction,2030,2030,24,percent,https://unfccc.int/sites/default/files/NDC/2022-09/Updated%20NDC%20_Uganda_2022%20Final.pdf,net_zero_tracker
-net_zero_tracker:AD:2030,AD,Relative emission reduction,2030,2030,55,percent,https://unfccc.int/sites/default/files/NDC/2022-11/20222410_Actualitzacio%20NDC.pdf,net_zero_tracker
-net_zero_tracker:AE:2030,AE,Relative emission reduction,2030,2030,31,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/United%20Arab%20Emirates%20Second/UAE%20Second%20NDC%20-%20UNFCCC%20Submission%20-%20English%20-%20FINAL.pdf,net_zero_tracker
-net_zero_tracker:AF:2030,AF,Relative emission reduction,2030,2030,13,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
-net_zero_tracker:AM:2030,AM,Absolute emission reduction,1990,2030,40,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Armenia%20First/NDC%20of%20Republic%20of%20Armenia%20%202021-2030.pdf,net_zero_tracker
-net_zero_tracker:AO:2025,AO,Absolute emission reduction,2015,2025,14,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Angola%20First/NDC%20Angola.pdf,net_zero_tracker
-net_zero_tracker:AT:2030,AT,Absolute emission reduction,1990,2030,55,percent,https://www.climatewatchdata.org/countries/AUT?end_year=2018&start_year=1990#ndc-content-overview,net_zero_tracker
-net_zero_tracker:AU:2030,AU,Absolute emission reduction,2005,2030,43,percent,https://unfccc.int/sites/default/files/NDC/2022-06/Australias%20NDC%20June%202022%20Update%20%283%29.pdf,net_zero_tracker
-net_zero_tracker:BA:2030,BA,Absolute emission reduction,2014,2030,12,percent,https://www.climatewatchdata.org/ndcs/country/BIH?document=revised_first_ndc,net_zero_tracker
-net_zero_tracker:BB:2030,BB,Absolute emission reduction,2008,2030,70,percent,https://htmlpreview.github.io/?https://github.com/WRI-ClimateWatch/ndc/blob/master/BRB-revised_first_ndc-EN.html,net_zero_tracker
-net_zero_tracker:BD:2030,BD,Absolute emission reduction,2012,2030,15,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Bangladesh%20First/NDC_submission_20210826revised.pdf,net_zero_tracker
-net_zero_tracker:BE:2030,BE,Absolute emission reduction,1990,2030,55,percent,https://unfccc.int/sites/default/files/resource/LTS_BE_EN_summary.pdf,net_zero_tracker
-net_zero_tracker:BF:2030,BF,Relative emission reduction,2030,2030,11,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
-net_zero_tracker:BG:2030,BG,Absolute emission reduction,1990,2030,40,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/12/1312-Annex-Alliance-ENGLISH-VF-2012.pdf,net_zero_tracker
-net_zero_tracker:BI:2030,BI,Relative emission reduction,2030,2030,20,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/12/1312-Annex-Alliance-ENGLISH-VF-2012.pdf,net_zero_tracker
-net_zero_tracker:BR:2025,BR,Absolute emission reduction,2005,2025,37,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Brazil%20First/2021%20-%20Carta%20MRE.pdf,net_zero_tracker
-net_zero_tracker:BS:2030,BS,Relative emission reduction,2030,2030,30,percent,https://unfccc.int/sites/default/files/NDC/2022-11/Bahamas%20Updated%20Nationally%20Determined%20Contributio,net_zero_tracker
-net_zero_tracker:CA:2030,CA,Absolute emission reduction,2005,2030,45,percent,https://www.canada.ca/en/services/environment/weather/climatechange/climate-plan/net-zero-emissions-2050.html,net_zero_tracker
-net_zero_tracker:CF:2030,CF,Relative emission reduction,2030,2030,24,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
-net_zero_tracker:CG:2025,CG,Absolute emission reduction,2017,2025,48,percent,https://ndcpartnership.org/countries-map/country?iso=COG,net_zero_tracker
-net_zero_tracker:CH:2030,CH,Absolute emission reduction,1990,2030,50,percent,https://www.admin.ch/gov/en/start/documentation/media-releases.msg-id-82140.html,net_zero_tracker
-net_zero_tracker:CN:2030,CN,Relative emission reduction,2005,2030,65,percent,https://unfccc.int/sites/default/files/NDC/2022-11/Progress%20of%20China%20NDC%202022.pdf,net_zero_tracker
-net_zero_tracker:CO:2030,CO,Relative emission reduction,2030,2030,51,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Colombia%20First/NDC%20actualizada%20de%20Colombia.pdf,net_zero_tracker
-net_zero_tracker:CV:2030,CV,Relative emission reduction,2030,2030,24,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Cabo%20Verde%20First/Cabo%20Verde_NDC%20Update%202021.pdf,net_zero_tracker
-net_zero_tracker:CY:2030,CY,Absolute emission reduction,1990,2030,55,percent,https://ec.europa.eu/energy/sites/default/files/documents/cy_final_necp_main_en.pdf,net_zero_tracker
-net_zero_tracker:DE:2030,DE,Absolute emission reduction,1990,2030,65,percent,https://www.bundesregierung.de/breg-de/themen/klimaschutz/climate-change-act-2021-1936846,net_zero_tracker
-net_zero_tracker:DK:2030,DK,Absolute emission reduction,1990,2030,70,percent,https://en.kefm.dk/news/news-archive/2019/dec/during-the-cop-denmark-passes-climate-act-with-a-70-percent-reduction-targetws-page-eng,net_zero_tracker
-net_zero_tracker:DM:2025,DM,Absolute emission reduction,2014,2025,39,percent,https://unfccc.int/sites/default/files/2022-07/The%20Commonwealth%20of%20Dominica%20updated%20NDC%20July%204%20%2C.pdf,net_zero_tracker
-net_zero_tracker:DO:2030,DO,Relative emission reduction,2030,2030,27,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Dominican%20Republic%20First/INDC-DR%20August%202015%20(unofficial%20translation).pdf,net_zero_tracker
-net_zero_tracker:EE:2030,EE,Absolute emission reduction,1990,2030,70,percent,https://www.europarl.europa.eu/thinktank/de/document.html?reference=EPRS_BRI%282021%29690684,net_zero_tracker
-net_zero_tracker:ER:2025,ER,Absolute emission reduction,2010,2025,6,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/12/1312-Annex-Alliance-ENGLISH-VF-2012.pdf,net_zero_tracker
-net_zero_tracker:ES:2030,ES,Absolute emission reduction,1990,2030,23,percent,https://boe.es/buscar/act.php?id=BOE-A-2021-8447#top,net_zero_tracker
-net_zero_tracker:ET:2030,ET,Relative emission reduction,2030,2030,68,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Ethiopia%20First/Ethiopia%27s%20updated%20NDC%20JULY%202021%20Submission_.pdf,net_zero_tracker
-net_zero_tracker:FI:2030,FI,Absolute emission reduction,2005,2030,55,percent,https://ym.fi/en/finland-s-national-climate-change-policy,net_zero_tracker
-net_zero_tracker:FM:2025,FM,Absolute emission reduction,2000,2025,28,percent,https://unfccc.int/sites/default/files/NDC/2022-10/Updated_NDC_of_the_Federated_States_of_Micronesia.pdf,net_zero_tracker
-net_zero_tracker:FR:2030,FR,Absolute emission reduction,1990,2030,55,percent,https://www.climatewatchdata.org/countries/FRA,net_zero_tracker
-net_zero_tracker:GB:2030,GB,Absolute emission reduction,1990,2030,68,percent,https://unfccc.int/sites/default/files/NDC/2022-09/UK%20NDC%20ICTU%202022.pdf,net_zero_tracker
-net_zero_tracker:GD:2025,GD,Absolute emission reduction,2010,2025,30,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Grenada%20Second/GrenadaSecondNDC2020%20-%2001-12-20.pdf,net_zero_tracker
-net_zero_tracker:GM:2030,GM,Relative emission reduction,2030,2030,49,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Gambia%20Second%20NDC/Second%20NDC%20of%20The%20Republic%20of%20The%20Gambia.pdf,net_zero_tracker
-net_zero_tracker:GN:2030,GN,Absolute emission reduction,1994,2030,13,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
-net_zero_tracker:GQ:2030,GQ,Absolute emission reduction,2010,2030,20,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Equatorial%20Guinea%20First/Rep%C3%BAblica%20de%20Guinea%20Ecuatorial_INDC.pdf,net_zero_tracker
-net_zero_tracker:GR:2030,GR,Absolute emission reduction,2021,2030,55,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Greece%20First/EU_NDC_Submission_December%202020.pdf,net_zero_tracker
-net_zero_tracker:GW:2030,GW,Relative emission reduction,2030,2030,30,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Guinea-Bissau%20First/NDC-Guinea%20Bissau-12102021.Final.pdf,net_zero_tracker
-net_zero_tracker:HR:2030,HR,Absolute emission reduction,1990,2030,36,percent,https://mingor.gov.hr/UserDocsImages/klimatske_aktivnosti/odrzivi_razvoj/NUS/lts_nus_eng.pdf,net_zero_tracker
-net_zero_tracker:HT:2030,HT,Relative emission reduction,2030,2030,6,percent,https://unfccc.int/sites/default/files/NDC/2022-06/CDN%20Revisee%20Haiti%202022.pdf,net_zero_tracker
-net_zero_tracker:HU:2030,HU,Absolute emission reduction,1990,2030,40,percent,https://www.parlament.hu/irom41/07021/07021-0010.pdf,net_zero_tracker
-net_zero_tracker:ID:2030,ID,Absolute emission reduction,2030,2030,29,percent,https://unfccc.int/sites/default/files/NDC/2022-09/ENDC%20Indonesia.pdf,net_zero_tracker
-net_zero_tracker:IE:2030,IE,Absolute emission reduction,1990,2030,55,percent,https://static.rasset.ie/documents/news/2020/06/draft-programme-for-govt.pdfhttps://www.gov.ie/pdf/?file=https://assets.gov.ie/42213/752d5346b9c6407b9125fdadfa0738a4.pdf#page=1,net_zero_tracker
-net_zero_tracker:IL:2030,IL,Absolute emission reduction,2015,2030,27,percent,https://www.jpost.com/climate-change/cop26-israel-to-aim-for-zero-net-emissions-by-2050-683470,net_zero_tracker
-net_zero_tracker:IN:2030,IN,Relative emission reduction,2005,2030,45,percent,https://unfccc.int/sites/default/files/NDC/2022-08/India%20Updated%20First%20Nationally%20Determined%20Contrib.pdf,net_zero_tracker
-net_zero_tracker:IS:2030,IS,Absolute emission reduction,1990,2030,55,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Iceland%20First/Iceland_updated_NDC_Submission_Feb_2021.pdf,net_zero_tracker
-net_zero_tracker:IT:2030,IT,Absolute emission reduction,1990,2030,55,percent,https://ec.europa.eu/clima/sites/lts/lts_it_it.pdf,net_zero_tracker
-net_zero_tracker:JP:2030,JP,Absolute emission reduction,2013,2030,46,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Japan%20First/JAPAN_FIRST%20NDC%20(INTERIM-UPDATED%20SUBMISSION).pdf,net_zero_tracker
-net_zero_tracker:KG:2030,KG,Relative emission reduction,2030,2030,29,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Kyrgyzstan%20First/Kyrgyzstan%20INDC%20_ENG_%20final.pdf,net_zero_tracker
-net_zero_tracker:KH:2030,KH,Relative emission reduction,2030,2030,41,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
-net_zero_tracker:KM:2030,KM,Relative emission reduction,2030,2030,23,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
-net_zero_tracker:KR:2030,KR,Absolute emission reduction,2018,2030,40,percent,https://unfccc.int/sites/default/files/NDC/2022-06/211223_The%20Republic%20of%20Korea%27s%20Enhanced%20Update%20of%20its%20First%20Nationally%20Determined%20Contribution_211227_editorial%20change.pdf,net_zero_tracker
-net_zero_tracker:KZ:2030,KZ,Absolute emission reduction,1990,2030,25,percent,https://legalacts.egov.kz/npa/view?id=11488215,net_zero_tracker
-net_zero_tracker:LA:2030,LA,Relative emission reduction,2030,2030,60,percent,"https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Lao%20People%27s%20Democratic%20Republic%20First/NDC%202020%20of%20Lao%20PDR%20(English),%2009%20April%202021%20(1).pdf",net_zero_tracker
-net_zero_tracker:LB:2030,LB,Relative emission reduction,2030,2030,31,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Lebanon%20First/Lebanon%27s%202020%20Nationally%20Determined%20Contribution%20Update.pdf,net_zero_tracker
-net_zero_tracker:LC:2025,LC,Relative emission reduction,2025,2025,16,percent,https://unfccc.int/sites/default/files/NDC/2022-06/Saint%20Lucia%20First%20NDC%20%28Updated%20submission%29.pdf,net_zero_tracker
-net_zero_tracker:LR:2030,LR,Relative emission reduction,2030,2030,10,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Liberia%20First/INDC%20Final%20Submission%20Sept%2030%202015%20Liberia.pdf,net_zero_tracker
-net_zero_tracker:LS:2030,LS,Absolute emission reduction,2015,2030,35,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Lesotho%20First/Lesotho%20First%20NDC.pdf,net_zero_tracker
-net_zero_tracker:LT:2030,LT,Absolute emission reduction,1990,2030,55,percent,https://www.oecd-ilibrary.org/environment/oecd-environmental-performance-reviews-lithuania-2021_48d82b17-en,net_zero_tracker
-net_zero_tracker:LU:2030,LU,Absolute emission reduction,2005,2030,55,percent,"https://legilux.public.lu/eli/etat/leg/loi/2020/12/15/a994/jo#:~:text=La%20pr%C3%A9sente%20loi%20%C3%A9tablit%20un,par%20rapport%20aux%20niveaux%20pr%C3%A9industriels.",net_zero_tracker
-net_zero_tracker:LV:2030,LV,Absolute emission reduction,1990,2030,40,percent,https://ec.europa.eu/clima/sites/lts/lts_lv_en.pdf,net_zero_tracker
-net_zero_tracker:MC:2030,MC,Absolute emission reduction,1990,2030,55,percent,https://www.docdroid.net/gavlB6o/190922-rmi-unsg-summit-release-leaders-statement-final-combined-pdf,net_zero_tracker
-net_zero_tracker:MG:2030,MG,Relative emission reduction,2030,2030,32,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Madagascar%20First/Madagascar%20INDC%20Eng.pdf,net_zero_tracker
-net_zero_tracker:MH:2025,MH,Absolute emission reduction,2010,2025,32,percent,https://unfccc.int/sites/default/files/resource/180924%20rmi%202050%20climate%20strategy%20final_0.pdf,net_zero_tracker
-net_zero_tracker:ML:2030,ML,Relative emission reduction,2030,2030,22,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/12/1312-Annex-Alliance-ENGLISH-VF-2012.pdf,net_zero_tracker
-net_zero_tracker:MR:2030,MR,Relative emission reduction,2030,2030,11,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Mauritania%20First/CDN-actualis%C3%A9%202021_%20Mauritania.pdf,net_zero_tracker
-net_zero_tracker:MT:2030,MT,Absolute emission reduction,2005,2030,19,percent,https://meae.gov.mt/en/Public_Consultations/MECP/PublishingImages/Pages/Consultations/MaltasLowCarbonDevelopmentStrategy/Malta%20Low%20Carbon%20Development%20Strategy.pdf,net_zero_tracker
-net_zero_tracker:MU:2030,MU,Relative emission reduction,2030,2030,40,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Mauritius%20First/Final%20INDC%20for%20Mauritius%2028%20Sept%202015.pdf,net_zero_tracker
-net_zero_tracker:MW:2030,MW,Relative emission reduction,2030,2030,50,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Malawi%20First/Malawi%20NDC_Policy%20Brief_30%20June%202021.pdf,net_zero_tracker
-net_zero_tracker:MX:2030,MX,Absolute emission reduction,2000,2030,35,percent,https://unfccc.int/sites/default/files/NDC/2022-11/Mexico_NDC_UNFCCC_update2022_FINAL.pdf,net_zero_tracker
-net_zero_tracker:MY:2030,MY,Relative emission reduction,2005,2030,45,percent,https://rmke12.epu.gov.my/en,net_zero_tracker
-net_zero_tracker:NA:2030,NA,Relative emission reduction,2030,2030,91,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Namibia%20First/Namibia%27s%20Updated%20NDC_%20FINAL%2025%20July%202021.pdf,net_zero_tracker
-net_zero_tracker:NG:2030,NG,Relative emission reduction,2030,2030,47,percent,https://www.bloomberg.com/news/articles/2021-11-02/nigeria-targets-to-reach-net-zero-emissions-by-2060-buhari-says,net_zero_tracker
-net_zero_tracker:NL:2030,NL,Absolute emission reduction,1990,2030,49,percent,https://www.cbs.nl/en-gb/news/2022/06/urgenda-reduction-target-for-ghg-emissions-achieved-in-2020,net_zero_tracker
-net_zero_tracker:NO:2030,NO,Absolute emission reduction,1990,2030,55,percent,https://unfccc.int/sites/default/files/NDC/2022-11/NDC%20Norway_second%20update.pdf,net_zero_tracker
-net_zero_tracker:OM:2030,OM,Relative emission reduction,2030,2030,7,percent,https://www.muscatdaily.com/2022/10/11/oman-commits-to-net-zero-by-2050/,net_zero_tracker
-net_zero_tracker:PK:2030,PK,Relative emission reduction,2030,2030,50,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Pakistan%20First/Pakistan%20Updated%20NDC%202021.pdf,net_zero_tracker
-net_zero_tracker:PT:2030,PT,Absolute emission reduction,2020,2030,40,percent,https://unfccc.int/sites/default/files/resource/HR-03-06-2020%20EU%20Submission%20on%20Long%20term%20strategy.pdf,net_zero_tracker
-net_zero_tracker:PW:2025,PW,Relative emission reduction,2025,2025,48,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Palau%20First/Palau_INDC.Final%20Copy.pdf,net_zero_tracker
-net_zero_tracker:RO:2030,RO,Absolute emission reduction,2005,2030,44,percent,https://ec.europa.eu/energy/sites/default/files/documents/ro_final_necp_main_en.pdf,net_zero_tracker
-net_zero_tracker:RU:2030,RU,Absolute emission reduction,1990,2030,70,percent,http://static.government.ru/media/files/ADKkCzp3fWO32e2yA0BhtIpyzWfHaiUa.pdf,net_zero_tracker
-net_zero_tracker:SB:2025,SB,Relative emission reduction,2025,2025,27,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Solomon%20Islands%20First/NDC%20Report%202021%20Final%20Solomon%20Islands%20(1).pdf,net_zero_tracker
-net_zero_tracker:SE:2030,SE,Absolute emission reduction,1990,2030,63,percent,https://www.government.se/495f60/contentassets/883ae8e123bc4e42aa8d59296ebe0478/the-swedish-climate-policy-framework.pdf,net_zero_tracker
-net_zero_tracker:SI:2030,SI,Absolute emission reduction,2005,2030,36,percent,https://unfccc.int/sites/default/files/resource/LTS1_SLOVENIA_EN.pdf,net_zero_tracker
-net_zero_tracker:SK:2030,SK,Absolute emission reduction,1990,2030,40,percent,https://unfccc.int/sites/default/files/resource/LTS%20SK%20eng.pdf,net_zero_tracker
-net_zero_tracker:SO:2030,SO,Relative emission reduction,2030,2030,30,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Somalia%20First/Final%20Updated%20NDC%20for%20Somalia%202021.pdf,net_zero_tracker
-net_zero_tracker:ST:2030,ST,Relative emission reduction,2030,2030,27,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
-net_zero_tracker:TD:2030,TD,Absolute emission reduction,2018,2030,19,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
-net_zero_tracker:TG:2030,TG,Absolute emission reduction,2010,2030,20,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
-net_zero_tracker:TH:2030,TH,Relative emission reduction,2030,2030,30,percent,https://unfccc.int/sites/default/files/NDC/2022-11/Thailand%202nd%20Updated%20NDC.pdf,net_zero_tracker
-net_zero_tracker:TR:2030,TR,Relative emission reduction,2030,2030,21,percent,https://www2.tbmm.gov.tr/d27/2/2-3853.pdf,net_zero_tracker
-net_zero_tracker:TT:2030,TT,Relative emission reduction,2030,2030,15,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
-net_zero_tracker:TV:2025,TV,Absolute emission reduction,2010,2025,60,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
-net_zero_tracker:UA:2030,UA,Absolute emission reduction,1990,2030,65,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Ukraine%20First/Ukraine%20NDC_July%2031.pdf,net_zero_tracker
-net_zero_tracker:US:2030,US,Absolute emission reduction,2005,2030,52,percent,https://www.whitehouse.gov/wp-content/uploads/2021/10/US-Long-Term-Strategy.pdf,net_zero_tracker
-net_zero_tracker:VN:2030,VN,Relative emission reduction,2030,2030,15,percent,https://unfccc.int/sites/default/files/NDC/2022-11/Viet%20Nam%20NDC%202022%20Update.pdf,net_zero_tracker
-net_zero_tracker:WS:2030,WS,Absolute emission reduction,2007,2030,26,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
-net_zero_tracker:YE:2030,YE,Absolute emission reduction,2020,2030,14,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
-net_zero_tracker:ZM:2030,ZM,Relative emission reduction,2030,2030,25,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
-net_zero_tracker:CA-BC:2050,CA-BC,Absolute emission reduction,2007,2050,80,percent,https://www2.gov.bc.ca/gov/content/environment/climate-change,net_zero_tracker
-net_zero_tracker:CA-NL:2050,CA-NL,Absolute emission reduction,1990,2050,85,percent,https://www.gov.nl.ca/releases/2020/mae/0605n04/,net_zero_tracker
-net_zero_tracker:CA-ON:2030,CA-ON,Absolute emission reduction,2005,2030,30,percent,https://prod-environmental-registry.s3.amazonaws.com/2018-11/EnvironmentPlan.pdf,net_zero_tracker
-net_zero_tracker:DE-HB:2020,DE-HB,Absolute emission reduction,1990,2020,40,percent,https://www.bauumwelt.bremen.de/klimaschutz/klima-energie/klimaschutz-in-bremen-24312,net_zero_tracker
-net_zero_tracker:DE-HH:2050,DE-HH,Absolute emission reduction,1990,2050,95,percent,https://www.landesrecht-hamburg.de/bsha/document/jlr-KlimaSchGHA2020pP4,net_zero_tracker
-net_zero_tracker:ES-AR:2030,ES-AR,Absolute emission reduction,1990,2030,40,percent,https://www.aragon.es/documents/20127/674325/ESTRATEGIA_ARAGONESA_CAMBIO_CLIMATICO.pdf/f4206c8d-94e0-acdd-9fb3-2e69f9d9b7dd,net_zero_tracker
-net_zero_tracker:ES-CM:2030,ES-CM,Absolute emission reduction,2005,2030,26,percent,https://www.castillalamancha.es/gobierno/desarrollosostenible/estructura/dgecocir/actuaciones/estrategia-de-cambio-clim%C3%A1tico-de-castilla-la-mancha-2020-2030,net_zero_tracker
-net_zero_tracker:ES-MC:2030,ES-MC,Absolute emission reduction,2016,2030,40,percent,https://www.murcia.es/medio-ambiente/medio-ambiente/material/estrategia_cambio_climatico/Estrategia_ONLINE%20cambio%20climatico.pdf,net_zero_tracker
-net_zero_tracker:ES-MD:2030,ES-MD,Absolute emission reduction,1990,2030,40,percent,https://www.madrid.es/UnidadesDescentralizadas/Sostenibilidad/CalidadAire/Ficheros/PlanAire&CC_Eng.pdf,net_zero_tracker
-net_zero_tracker:ES-NA:2050,ES-NA,Absolute emission reduction,2005,2050,80,percent,https://lifenadapta.navarra.es/documents/2696321/2696934/GN_KLINA_Res_ing_rev_190122.pdf/62f9da85-be55-a740-e428-98039e634210?t=1582010696850,net_zero_tracker
-net_zero_tracker:ES-NC:2050,ES-NC,Absolute emission reduction,2005,2050,80,percent,https://lifenadapta.navarra.es/documents/2696321/2696934/LIFE+NAdapta_+Hoja+de+Ruta+KLINA.pdf/26ff0133-329b-d42b-fb56-290f1d3362fd?t=1557401328262,net_zero_tracker
-net_zero_tracker:ES-PV:2050,ES-PV,Absolute emission reduction,1990,2050,80,percent,https://www.theclimategroup.org/states-and-regions-under2-coalition,net_zero_tracker
-net_zero_tracker:FR-NOR:2030,FR-NOR,Absolute emission reduction,2015,2030,50,percent,https://terrifica.eu/wp-content/uploads/2019/09/TeRRIFICA_FRANCE_state_of_art_OnlinePublication.pdf,net_zero_tracker
-net_zero_tracker:FR-PDL:2030,FR-PDL,Absolute emission reduction,2015,2030,50,percent,https://terrifica.eu/wp-content/uploads/2019/09/TeRRIFICA_FRANCE_state_of_art_OnlinePublication.pdf,net_zero_tracker
-net_zero_tracker:MX-BCN:2030,MX-BCN,Absolute emission reduction,2021,2030,25,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Under2%20Coalition%20Baja-California%20Appendix.pdf,net_zero_tracker
-net_zero_tracker:MX-CAM:2050,MX-CAM,Absolute emission reduction,1990,2050,80,percent,https://www.theclimategroup.org/sites/default/files/2020-10/apendice_campeche.pdf,net_zero_tracker
-net_zero_tracker:MX-COL:2050,MX-COL,Absolute emission reduction,2010,2050,50,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Colima-Appendix-English.pdf,net_zero_tracker
-net_zero_tracker:MX-NLE:2050,MX-NLE,Absolute emission reduction,1990,2050,95,percent,https://www.theclimategroup.org/sites/default/files/2020-10/nuevo_leon_apendice.pdf,net_zero_tracker
-net_zero_tracker:MX-OAX:2050,MX-OAX,Relative emission reduction,2013,2050,58,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Under2MOU%20Ap%C3%A9ndice%20Oaxaca.pdf,net_zero_tracker
-net_zero_tracker:MX-ROO:2050,MX-ROO,Absolute emission reduction,2016,2050,63,percent,https://www.theclimategroup.org/sites/default/files/2021-10/Quintana%20Roo%20Pathway%20Executive%20Summary.pdf,net_zero_tracker
-net_zero_tracker:MX-SON:2050,MX-SON,Absolute emission reduction,2010,2050,95,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Under2%20Coalition%20Sonora%20Appendix.pdf,net_zero_tracker
-net_zero_tracker:MX-YUC:2030,MX-YUC,Relative emission reduction,2005,2030,40,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Yucatan-appendix.pdf,net_zero_tracker
-net_zero_tracker:MY-04:2030,MY-04,Absolute emission reduction,2015,2030,45,percent,https://www.academia.edu/41117425/MELAKA_STATE_CLIMATE_ACTION_PLAN_2020_2030_Prepared_by,net_zero_tracker
-net_zero_tracker:US-CO:2050,US-CO,Absolute emission reduction,2005,2050,90,percent,https://leg.colorado.gov/bills/hb19-1261,net_zero_tracker
-net_zero_tracker:US-CT:2050,US-CT,Absolute emission reduction,1990,2050,80,percent,https://portal.ct.gov/-/media/DEEP/climatechange/publications/BuildingaLowCarbonFutureforCTGC3Recommendationspdf.pdf,net_zero_tracker
-net_zero_tracker:US-DE:2030,US-DE,Absolute emission reduction,2008,2030,30,percent,https://documents.dnrec.delaware.gov/energy/Documents/2016%20Climate%20Action%20Progress%20Report/Climate%20Action%20in%20Delaware%202016%20Progress%20Report.pdf,net_zero_tracker
-net_zero_tracker:US-FL:2050,US-FL,Absolute emission reduction,1990,2050,80,percent,https://www.fsec.ucf.edu/en/media/enews/2007/pdf/07-127-emissions.pdf,net_zero_tracker
-net_zero_tracker:US-GA:2030,US-GA,Absolute emission reduction,1990,2030,35,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Georgia%20First/NDC%20Georgia_ENG%20WEB-approved.pdf,net_zero_tracker
-net_zero_tracker:US-MN:2050,US-MN,Absolute emission reduction,2005,2050,80,percent,https://climate.state.mn.us/,net_zero_tracker
-net_zero_tracker:US-NH:2050,US-NH,Absolute emission reduction,2001,2050,80,percent,nan,net_zero_tracker
-net_zero_tracker:US-OR:2050,US-OR,Absolute emission reduction,1990,2050,80,percent,https://www.oregon.gov/gov/Documents/executive_orders/eo_20-04.pdf,net_zero_tracker
-net_zero_tracker:US-PA:2050,US-PA,Absolute emission reduction,2005,2050,80,percent,https://www.dep.pa.gov/Citizens/climate/Pages/PA-Climate-Action-Plan.aspx,net_zero_tracker
-net_zero_tracker:US-RI:2050,US-RI,Absolute emission reduction,1990,2050,80,percent,http://climatechange.ri.gov/state-actions/governor-climate-priorities.php,net_zero_tracker
-net_zero_tracker:US-UT:2050,US-UT,Absolute emission reduction,2005,2050,80,percent,https://gardner.utah.edu/utahroadmap/,net_zero_tracker
-net_zero_tracker:US-VT:2050,US-VT,Absolute emission reduction,1990,2050,80,percent,http://climatechange.ri.gov/state-actions/governor-climate-priorities.php,net_zero_tracker
-net_zero_tracker:ZA-GP:2030,ZA-GP,Absolute emission reduction,2010,2030,66,percent,https://amcham.co.za/wp-content/uploads/2020/12/Gauteng-City-Region-Over-arching-Climate-Change-Response-Strategy-and-Action-Plan-March-2020-Final.pdf,net_zero_tracker
-net_zero_tracker:AU-ACT:2025,AU-ACT,Absolute emission reduction,1990,2025,60,percent,"https://www.environment.act.gov.au/__data/assets/pdf_file/0003/1414641/ACT-Climate-Change-Strategy-2019-2025.pdf/_recache#:~:text=The%20Australian%20Capital%20Territory%20(ACT,reduction%20in%20emissions%20by%202020.",net_zero_tracker
-net_zero_tracker:AU-NSW:2030,AU-NSW,Absolute emission reduction,2005,2030,50,percent,https://www.energy.nsw.gov.au/nsw-plans-and-progress/government-strategies-and-frameworks/reaching-net-zero-emissions,net_zero_tracker
-net_zero_tracker:AU-QLD:2030,AU-QLD,Absolute emission reduction,2005,2030,30,percent,https://www.qld.gov.au/__data/assets/pdf_file/0026/67283/qld-climate-transition-strategy.pdf,net_zero_tracker
-net_zero_tracker:AU-SA:2030,AU-SA,Absolute emission reduction,2005,2030,50,percent,https://www.environment.sa.gov.au/topics/climate-change/government-action-on-climate-change,net_zero_tracker
-net_zero_tracker:AU-VIC:2035,AU-VIC,Absolute emission reduction,2005,2035,75,percent,https://www.danandrews.com.au/news/putting-power-back-in-the-hands-of-victorians,net_zero_tracker
-net_zero_tracker:CA-BC:2040,CA-BC,Absolute emission reduction,2007,2040,60,percent,https://www2.gov.bc.ca/gov/content/environment/climate-change,net_zero_tracker
-net_zero_tracker:CA-MB:2030,CA-MB,Absolute emission reduction,2005,2030,33,percent,https://www.gov.mb.ca/sd/annual-reports/sdif/mb-climate-change-green-economy-action-plan.pdf,net_zero_tracker
-net_zero_tracker:CA-NL:2020,CA-NL,Absolute emission reduction,1990,2020,10,percent,https://www.gov.nl.ca/releases/2020/mae/0605n04/,net_zero_tracker
-net_zero_tracker:CA-NS:2030,CA-NS,Absolute emission reduction,1990,2030,53,percent,https://nslegislature.ca/legc/bills/63rd_2nd/3rd_read/b213.htm,net_zero_tracker
-net_zero_tracker:CA-NT:2030,CA-NT,Absolute emission reduction,2005,2030,50,percent,https://www.ntassembly.ca/sites/assembly/files/td_103-192.pdf,net_zero_tracker
-net_zero_tracker:CA-PE:2030,CA-PE,Absolute emission reduction,2005,2030,30,percent,https://www.princeedwardisland.ca/sites/default/files/publications/pei_path_towards_net_zero_framework.pdf,net_zero_tracker
-net_zero_tracker:CA-QC:2030,CA-QC,Absolute emission reduction,1990,2030,37,percent,https://www.quebec.ca/en/government/policies-orientations/plan-green-economy,net_zero_tracker
-net_zero_tracker:CA-YT:2030,CA-YT,Absolute emission reduction,2010,2030,30,percent,https://yukon.ca/sites/yukon.ca/files/env/env-our-clean-future.pdf,net_zero_tracker
-net_zero_tracker:DE-BE:2030,DE-BE,Absolute emission reduction,1990,2030,70,percent,https://gesetze.berlin.de/bsbe/document/jlr-EWendGBErahmen,net_zero_tracker
-net_zero_tracker:DE-BW:2030,DE-BW,Absolute emission reduction,1990,2030,25,percent,https://um.baden-wuerttemberg.de/fileadmin/redaktion/m-um/intern/Dateien/Dokumente/4_Klima/Klimaschutz/Klimaschutzgesetz/Klimaschutzgesetz-Baden-Wuerttemberg-englische-Fassung-Januar-2021.pdf,net_zero_tracker
-net_zero_tracker:DE-BY:2030,DE-BY,Absolute emission reduction,1990,2030,55,percent,https://www.gesetze-bayern.de/Content/Document/BayKlimaG,net_zero_tracker
-net_zero_tracker:DE-HH:2030,DE-HH,Absolute emission reduction,1990,2030,55,percent,https://www.landesrecht-hamburg.de/bsha/document/jlr-KlimaSchGHA2020pP4,net_zero_tracker
-net_zero_tracker:DE-NW:2030,DE-NW,Absolute emission reduction,1990,2030,65,percent,https://www.klimaschutz.nrw.de/instrumente/klimaschutzgesetz,net_zero_tracker
-net_zero_tracker:DE-RP:2020,DE-RP,Absolute emission reduction,1990,2020,40,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Rhineland-Palatinate-Appendix-English.pdf,net_zero_tracker
-net_zero_tracker:DE-TH:2030,DE-TH,Absolute emission reduction,1990,2030,70,percent,https://www.swsz.de/die-swsz/medien-center/veroeffentlichungspflichten/thuerklimag,net_zero_tracker
-net_zero_tracker:ES-CN:2030,ES-CN,Absolute emission reduction,2010,2030,37,percent,https://www3.gobiernodecanarias.org/ceic/energia/oecan/files/20220214_Estrategia_Sostenible_Canarias_docCompleto_01.pdf,net_zero_tracker
-net_zero_tracker:ES-CT:2030,ES-CT,Absolute emission reduction,1990,2030,40,percent,https://canviclimatic.gencat.cat/ca/ambits/Llei_canvi_climatic/,net_zero_tracker
-net_zero_tracker:ES-MC:2020,ES-MC,Absolute emission reduction,2008,2020,20,percent,https://www.murcia.es/medio-ambiente/medio-ambiente/material/estrategia_cambio_climatico/Estrategia_ONLINE%20cambio%20climatico.pdf,net_zero_tracker
-net_zero_tracker:ES-MD:2020,ES-MD,Absolute emission reduction,2010,2020,36,percent,https://www.madrid.es/UnidadesDescentralizadas/Sostenibilidad/CalidadAire/Ficheros/PlanAire&CC_Eng.pdf,net_zero_tracker
-net_zero_tracker:ES-NA:2030,ES-NA,Absolute emission reduction,2005,2030,45,percent,https://lifenadapta.navarra.es/documents/2696321/2696934/GN_KLINA_Res_ing_rev_190122.pdf/62f9da85-be55-a740-e428-98039e634210?t=1582010696850,net_zero_tracker
-net_zero_tracker:ES-NC:2030,ES-NC,Absolute emission reduction,2005,2030,45,percent,https://lifenadapta.navarra.es/documents/2696321/2696934/LIFE+NAdapta_+Hoja+de+Ruta+KLINA.pdf/26ff0133-329b-d42b-fb56-290f1d3362fd?t=1557401328262,net_zero_tracker
-net_zero_tracker:ES-PV:2030,ES-PV,Absolute emission reduction,2005,2030,40,percent,https://www.theclimategroup.org/states-and-regions-under2-coalition,net_zero_tracker
-net_zero_tracker:FR-ARA:2030,FR-ARA,Absolute emission reduction,2015,2030,30,percent,https://www.auvergnerhonealpes-ee.fr/qui-sommes-nous/lagence-en-bref,net_zero_tracker
-net_zero_tracker:FR-NOR:2020,FR-NOR,Absolute emission reduction,2015,2020,30,percent,https://terrifica.eu/wp-content/uploads/2019/09/TeRRIFICA_FRANCE_state_of_art_OnlinePublication.pdf,net_zero_tracker
-net_zero_tracker:FR-PDL:2020,FR-PDL,Absolute emission reduction,2015,2020,30,percent,https://terrifica.eu/wp-content/uploads/2019/09/TeRRIFICA_FRANCE_state_of_art_OnlinePublication.pdf,net_zero_tracker
-net_zero_tracker:GB-ENG:2030,GB-ENG,Absolute emission reduction,1990,2030,68,percent,https://www.gov.uk/government/news/uk-enshrines-new-target-in-law-to-slash-emissions-by-78-by-2035,net_zero_tracker
-net_zero_tracker:GB-NIR:2030,GB-NIR,Absolute emission reduction,1990,2030,48,percent,http://www.niassembly.gov.uk/globalassets/documents/legislation/bills/executive-bills/session-2017-2022/climate-change-no.-2-bill/climate-chnage-no.-2-bill-as-amended-at-fcs---full-print-version.pdf,net_zero_tracker
-net_zero_tracker:GB-SCT:2030,GB-SCT,Absolute emission reduction,1990,2030,75,percent,https://www.legislation.gov.uk/asp/2019/15/contents/enacted,net_zero_tracker
-net_zero_tracker:GB-WLS:2030,GB-WLS,Absolute emission reduction,1990,2030,63,percent,https://gov.wales/sites/default/files/publications/2021-10/net-zero-wales-summary-document.pdf,net_zero_tracker
-net_zero_tracker:JP-01:2030,JP-01,Absolute emission reduction,2013,2030,31,percent,https://www.pref.aomori.lg.jp/soshiki/kankyo/kankyo/2050CO2zero.html,net_zero_tracker
-net_zero_tracker:JP-01:2030,JP-01,Absolute emission reduction,2013,2030,35,percent,https://www.pref.hokkaido.lg.jp/ks/tot/ontaikeikakukaitei.html,net_zero_tracker
-net_zero_tracker:JP-03:2030,JP-03,Absolute emission reduction,2013,2030,32,percent,https://www.pref.iwate.jp/kurashikankyou/kankyou/seisaku/1005573.html,net_zero_tracker
-net_zero_tracker:JP-04:2030,JP-04,Absolute emission reduction,2013,2030,31,percent,https://www.env.go.jp/policy/zerocarbon.html,net_zero_tracker
-net_zero_tracker:JP-06:2030,JP-06,Absolute emission reduction,2013,2030,26,percent,https://www.pref.yamagata.jp/050015/kurashi/kankyo/management/plan/4thplan.html,net_zero_tracker
-net_zero_tracker:JP-07:2030,JP-07,Absolute emission reduction,2013,2030,45,percent,https://www.pref.fukushima.lg.jp/sec/16035a/carbon-neutral.html,net_zero_tracker
-net_zero_tracker:JP-09:2030,JP-09,Absolute emission reduction,2013,2030,26,percent,https://www.pref.tochigi.lg.jp/d02/eco/kankyou/ondanka/documents/kikoukeikaku.pdf,net_zero_tracker
-net_zero_tracker:JP-10:2030,JP-10,Absolute emission reduction,2013,2030,50,percent,https://www.pref.gunma.jp/04/cp01_00022.html,net_zero_tracker
-net_zero_tracker:JP-12:2030,JP-12,Absolute emission reduction,2013,2030,22,percent,https://www.pref.chiba.lg.jp/shigen/chikyuukankyou/zerosengen.html,net_zero_tracker
-net_zero_tracker:JP-13:2030,JP-13,Absolute emission reduction,2000,2030,30,percent,https://www.kankyo.metro.tokyo.lg.jp/policy_others/zeroemission_tokyo/strategy_2020update.html,net_zero_tracker
-net_zero_tracker:JP-14:2030,JP-14,Absolute emission reduction,2013,2030,27,percent,https://www.pref.kanagawa.jp/documents/59045/datsutanso.pdf,net_zero_tracker
-net_zero_tracker:JP-15:2030,JP-15,Absolute emission reduction,2013,2030,26,percent,https://www.pref.niigata.lg.jp/site/kankyo/1239566486047.html,net_zero_tracker
-net_zero_tracker:JP-16:2030,JP-16,Absolute emission reduction,2013,2030,30,percent,https://www.pref.toyama.jp/100223/kurashi/kankyoushizen/kankyou/kj00021656.html,net_zero_tracker
-net_zero_tracker:JP-18:2030,JP-18,Absolute emission reduction,2013,2030,28,percent,https://www.pref.fukui.lg.jp/doc/kankyou/2050-co2-0.html,net_zero_tracker
-net_zero_tracker:JP-19:2030,JP-19,Absolute emission reduction,2013,2030,26,percent,https://www.pref.yamanashi.jp/kankyo-ene/stopondankayamanashikaigi.html,net_zero_tracker
-net_zero_tracker:JP-20:2030,JP-20,Absolute emission reduction,2010,2030,60,percent,https://www.pref.nagano.lg.jp/kankyo/keikaku/zerocarbon/index.html,net_zero_tracker
-net_zero_tracker:JP-21:2030,JP-21,Absolute emission reduction,2013,2030,33,percent,https://www.pref.gifu.lg.jp/page/8674.html,net_zero_tracker
-net_zero_tracker:JP-22:2021,JP-22,Absolute emission reduction,2005,2021,21,percent,https://www.pref.shizuoka.jp/kankyou/ka-030/earth/carbon-neutral.html,net_zero_tracker
-net_zero_tracker:JP-24:2030,JP-24,Absolute emission reduction,2013,2030,30,percent,https://www.pref.mie.lg.jp/common/01/ci500015424.htm,net_zero_tracker
-net_zero_tracker:JP-25:2030,JP-25,Absolute emission reduction,2013,2030,23,percent,https://www.pref.shiga.lg.jp/ippan/kankyoshizen/ondanka/309038.html,net_zero_tracker
-net_zero_tracker:JP-26:2030,JP-26,Absolute emission reduction,2013,2030,40,percent,https://www.pref.kyoto.jp/tikyu/suishinkeikaku.html,net_zero_tracker
-net_zero_tracker:JP-27:2030,JP-27,Absolute emission reduction,2013,2030,33,percent,https://www.kankyo.pref.hyogo.lg.jp/application/files/7016/1578/8440/b99e09762bd46d7c8ff9c64976693843.pdf,net_zero_tracker
-net_zero_tracker:JP-27:2030,JP-27,Absolute emission reduction,2013,2030,40,percent,https://www.pref.osaka.lg.jp/chikyukankyo/jigyotoppage/27_3keikaku.html,net_zero_tracker
-net_zero_tracker:JP-29:2030,JP-29,Absolute emission reduction,2013,2030,45,percent,http://www.eco.pref.nara.jp/jorei_kisoku/sogo_keikaku.html,net_zero_tracker
-net_zero_tracker:JP-30:2030,JP-30,Absolute emission reduction,2013,2030,30,percent,https://www.pref.wakayama.lg.jp/prefg/032000/envplan/index.html,net_zero_tracker
-net_zero_tracker:JP-31:2030,JP-31,Absolute emission reduction,2013,2030,40,percent,https://www.pref.tottori.lg.jp/initiative_plan/,net_zero_tracker
-net_zero_tracker:JP-32:2030,JP-32,Absolute emission reduction,2013,2030,21,percent,https://www.pref.shimane.lg.jp/infra/kankyo/kankyo/kankyo_sougou/sougoukeikaku.html,net_zero_tracker
-net_zero_tracker:JP-33:2030,JP-33,Absolute emission reduction,2013,2030,17,percent,https://www.env.go.jp/policy/zerocarbon.html,net_zero_tracker
-net_zero_tracker:JP-34:2030,JP-34,Absolute emission reduction,2013,2030,50,percent,https://www.pref.tokushima.lg.jp/ippannokata/kurashi/shizen/5035820,net_zero_tracker
-net_zero_tracker:JP-34:2030,JP-34,Absolute emission reduction,2013,2030,22,percent,https://www.pref.hiroshima.lg.jp/site/eco/b-b12-plan22-keikaku.html,net_zero_tracker
-net_zero_tracker:JP-35:2030,JP-35,Absolute emission reduction,2013,2030,27,percent,https://www.pref.ehime.jp/kankyou/k-hp/theme/ondanka/keikaku.html,net_zero_tracker
-net_zero_tracker:JP-36:2030,JP-36,Absolute emission reduction,2013,2030,27,percent,https://www.pref.saga.lg.jp/kiji00379726/index.html,net_zero_tracker
-net_zero_tracker:JP-37:2030,JP-37,Absolute emission reduction,2013,2030,31,percent,https://www.pref.nagasaki.jp/bunrui/kurashi-kankyo/kankyohozen-ondankataisaku/ondanka/ondanka-actionplan-dai2ji/,net_zero_tracker
-net_zero_tracker:JP-38:2030,JP-38,Absolute emission reduction,2013,2030,50,percent,https://www.pref.kumamoto.jp/soshiki/49/103587.html,net_zero_tracker
-net_zero_tracker:JP-39:2030,JP-39,Absolute emission reduction,2013,2030,33,percent,http://www.pref.kagoshima.jp/kawara/documents/89273_20210802111303-1.pdf,net_zero_tracker
-net_zero_tracker:JP-39:2030,JP-39,Absolute emission reduction,2013,2030,29,percent,https://www.pref.kochi.lg.jp/soshiki/030901/2021032500328.html,net_zero_tracker
-net_zero_tracker:JP-41:2030,JP-41,Absolute emission reduction,2013,2030,35,percent,https://www.pref.oita.jp/soshiki/13060/dai5kikeikaku.html,net_zero_tracker
-net_zero_tracker:JP-45:2030,JP-45,Absolute emission reduction,2013,2030,26,percent,http://www.pref.miyazaki.lg.jp/kankyoshinrin/kense/kekaku/20210303113521.html,net_zero_tracker
-net_zero_tracker:JP-47:2030,JP-47,Absolute emission reduction,2013,2030,26,percent,https://www.pref.okinawa.jp/site/kankyo/saisei/jikkkou-keikaku.html,net_zero_tracker
-net_zero_tracker:KR-49:2030,KR-49,Absolute emission reduction,2017,2030,33,percent,https://www.investkorea.org/jj-en/bbs/i-1536/detail.do?ntt_sn=2,net_zero_tracker
-net_zero_tracker:MX-BCN:2021,MX-BCN,Absolute emission reduction,2020,2021,15,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Under2%20Coalition%20Baja-California%20Appendix.pdf,net_zero_tracker
-net_zero_tracker:MX-COL:2030,MX-COL,Absolute emission reduction,2010,2030,30,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Colima-Appendix-English.pdf,net_zero_tracker
-net_zero_tracker:MX-JAL:2030,MX-JAL,Absolute emission reduction,2010,2030,45,percent,https://app.semadet.jalisco.gob.mx/cs/EECC_15042021.pdf,net_zero_tracker
-net_zero_tracker:MX-NLE:2030,MX-NLE,Absolute emission reduction,1990,2030,45,percent,https://www.theclimategroup.org/sites/default/files/2020-10/nuevo_leon_apendice.pdf,net_zero_tracker
-net_zero_tracker:MX-ROO:2030,MX-ROO,Absolute emission reduction,2016,2030,21,percent,https://www.theclimategroup.org/sites/default/files/2021-10/Quintana%20Roo%20Pathway%20Executive%20Summary.pdf,net_zero_tracker
-net_zero_tracker:MX-SON:2030,MX-SON,Absolute emission reduction,2010,2030,25,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Under2%20Coalition%20Sonora%20Appendix.pdf,net_zero_tracker
-net_zero_tracker:MX-YUC:2018,MX-YUC,Relative emission reduction,2005,2018,20,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Yucatan-appendix.pdf,net_zero_tracker
-net_zero_tracker:MY-04:2025,MY-04,Absolute emission reduction,2015,2025,30,percent,https://www.academia.edu/41117425/MELAKA_STATE_CLIMATE_ACTION_PLAN_2020_2030_Prepared_by,net_zero_tracker
-net_zero_tracker:US-CA:2030,US-CA,Absolute emission reduction,1990,2030,40,percent,https://www.ca.gov/archive/gov39/wp-content/uploads/2018/09/9.10.18-Executive-Order.pdf,net_zero_tracker
-net_zero_tracker:US-CO:2025,US-CO,Absolute emission reduction,2005,2025,26,percent,https://leg.colorado.gov/bills/hb19-1261,net_zero_tracker
-net_zero_tracker:US-CT:2030,US-CT,Absolute emission reduction,1990,2030,45,percent,https://portal.ct.gov/-/media/DEEP/climatechange/publications/BuildingaLowCarbonFutureforCTGC3Recommendationspdf.pdf,net_zero_tracker
-net_zero_tracker:US-DE:2025,US-DE,Absolute emission reduction,2005,2025,26,percent,https://documents.dnrec.delaware.gov/energy/Documents/2016%20Climate%20Action%20Progress%20Report/Climate%20Action%20in%20Delaware%202016%20Progress%20Report.pdf,net_zero_tracker
-net_zero_tracker:US-HI:2020,US-HI,Absolute emission reduction,1990,2020,19,percent,https://www.capitol.hawaii.gov/session2018/bills/HB2182_CD1_.htm,net_zero_tracker
-net_zero_tracker:US-IL:2025,US-IL,Absolute emission reduction,2005,2025,26,percent,https://www.illinois.gov/government/executive-orders/executive-order.executive-order-number-6.2019.html,net_zero_tracker
-net_zero_tracker:US-LA:2025,US-LA,Absolute emission reduction,2005,2025,26,percent,https://gov.louisiana.gov/assets/ExecutiveOrders/2020/JBE-2020-18-Climate-Initiatives-Task-Force.pdf,net_zero_tracker
-net_zero_tracker:US-MA:2030,US-MA,Absolute emission reduction,1990,2030,45,percent,https://malegislature.gov/Laws/SessionLaws/Acts/2021/Chapter8,net_zero_tracker
-net_zero_tracker:US-MD:2031,US-MD,Absolute emission reduction,2006,2031,60,percent,https://mgaleg.maryland.gov/2022RS/fnotes/bil_0008/sb0528.pdf,net_zero_tracker
-net_zero_tracker:US-ME:2030,US-ME,Absolute emission reduction,1990,2030,45,percent,https://www.maine.gov/governor/mills/sites/maine.gov.governor.mills/files/inline-files/Executive%20Order%209-23-2019_0.pdf,net_zero_tracker
-net_zero_tracker:US-MI:2025,US-MI,Absolute emission reduction,2005,2025,28,percent,https://www.michigan.gov/documents/egle/Draft-MI-Healthy-Climate-Plan_745872_7.pdf,net_zero_tracker
-net_zero_tracker:US-MN:2025,US-MN,Absolute emission reduction,2005,2025,30,percent,https://climate.state.mn.us/,net_zero_tracker
-net_zero_tracker:US-NH:2020,US-NH,Absolute emission reduction,1990,2020,10,percent,nan,net_zero_tracker
-net_zero_tracker:US-NV:2025,US-NV,Absolute emission reduction,2005,2025,28,percent,https://www.leg.state.nv.us/App/NELIS/REL/80th2019/Bill/6431/Text,net_zero_tracker
-net_zero_tracker:US-NY:2030,US-NY,Absolute emission reduction,1990,2030,40,percent,https://www.nysenate.gov/legislation/bills/2019/s6599,net_zero_tracker
-net_zero_tracker:US-OR:2035,US-OR,Absolute emission reduction,1990,2035,45,percent,https://www.oregon.gov/gov/Documents/executive_orders/eo_20-04.pdf,net_zero_tracker
-net_zero_tracker:US-PA:2025,US-PA,Absolute emission reduction,2005,2025,26,percent,https://www.dep.pa.gov/Citizens/climate/Pages/PA-Climate-Action-Plan.aspx,net_zero_tracker
-net_zero_tracker:US-UT:2025,US-UT,Absolute emission reduction,2005,2025,25,percent,https://gardner.utah.edu/utahroadmap/,net_zero_tracker
-net_zero_tracker:US-VT:2025,US-VT,Absolute emission reduction,2005,2025,26,percent,http://climatechange.ri.gov/state-actions/governor-climate-priorities.php,net_zero_tracker
-net_zero_tracker:US-WA:2030,US-WA,Absolute emission reduction,1990,2030,45,percent,https://ecology.wa.gov/Air-Climate/Climate-change/Greenhouse-gases,net_zero_tracker
-net_zero_tracker:ZA-GP:2020,ZA-GP,Absolute emission reduction,2010,2020,21,percent,https://amcham.co.za/wp-content/uploads/2020/12/Gauteng-City-Region-Over-arching-Climate-Change-Response-Strategy-and-Action-Plan-March-2020-Final.pdf,net_zero_tracker
-net_zero_tracker:ZA-KZN:2030,ZA-KZN,Absolute emission reduction,2015,2030,40,percent,"https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5c8ab5851647e100801756a3/5e5e3f71469c8b00a735fbac/files/Climate_Action_Plan_web.pdf?1583234929#:~:text=A%201.5%C2%B0C%20CAP,increase%20to%201.5%C2%B0C.",net_zero_tracker
-net_zero_tracker:BG SOF:2030,BG SOF,Absolute emission reduction,2007,2030,40,percent,https://www.ebrdgreencities.com/assets/Uploads/PDF/7181e1a1c8/Sofia-GCAP_ENG.pdf,net_zero_tracker
-net_zero_tracker:BR CPS:2060,BR CPS,Absolute emission reduction,2016,2060,32,percent,https://bibliotecajuridica.campinas.sp.gov.br/index/visualizaroriginal/id/136363,net_zero_tracker
-net_zero_tracker:CA CAL:2050,CA CAL,Absolute emission reduction,2005,2050,80,percent,https://www.calgary.ca/content/dam/www/uep/esm/documents/esm-documents/climate-resilience-strategy-and-action-plans-annual-report-2020.pdf,net_zero_tracker
-net_zero_tracker:CA OTT:2050,CA OTT,Absolute emission reduction,2012,2050,100,percent,https://documents.ottawa.ca/sites/documents/files/climate_change_mplan_en.pdf,net_zero_tracker
-net_zero_tracker:CA WNP:2050,CA WNP,Absolute emission reduction,2011,2050,80,percent,https://winnipeg.ca/sustainability/PublicEngagement/ClimateActionPlan/pdfs/CW_Climate-Action-Plan.pdf,net_zero_tracker
-net_zero_tracker:CN SGH:2035,CN SGH,Absolute emission reduction,2025,2035,5,percent,https://fgw.sh.gov.cn/zgjjl/20210701/23960c2ed0b543aa9d253604989bfdab.html,net_zero_tracker
-net_zero_tracker:CO CTG:2050,CO CTG,Absolute emission reduction,2008,2050,40,percent,https://plan4c.cartagena.gov.co/wp-content/uploads/2018/06/20150428171251_PLAN-DE-ADAPTACION-4C_ingles-1.pdf,net_zero_tracker
-net_zero_tracker:DE FRA:2050,DE FRA,Absolute emission reduction,1990,2050,95,percent,https://frankfurt.de/themen/klima-und-energie,net_zero_tracker
-net_zero_tracker:DE HAJ:2035,DE HAJ,Absolute emission reduction,1990,2035,95,percent,https://www.hannover.de/content/download/575256/file/23352_B_100%20Prozent%20Klimaschutz-engl-WEB.pdf,net_zero_tracker
-net_zero_tracker:ES ZAZ:2030,ES ZAZ,Absolute emission reduction,2005,2030,55,percent,http://www.zaragoza.es/contenidos/medioambiente/2021-PACES-Zaragoza-2030.pdf,net_zero_tracker
-net_zero_tracker:GE TBS:2030,GE TBS,Absolute emission reduction,1990,2030,39,percent,https://hexagonagility.com/story/how-tbilisi-is-improving-human-health-and-driving-its-transit-fleet-into-the-future/,net_zero_tracker
-net_zero_tracker:GR SKG:2030,GR SKG,Absolute emission reduction,2011,2030,40,percent,https://resilientcitiesnetwork.org/downloadable_resources/Network/Thessaloniki-Resilience-Strategy-English.pdf,net_zero_tracker
-net_zero_tracker:HR ZAG:2030,HR ZAG,Absolute emission reduction,2008,2030,40,percent,https://balkangreenenergynews.com/zagreb-adopts-first-sustainable-energy-and-climate-action-plan-in-croatia/,net_zero_tracker
-net_zero_tracker:IE DUB:2030,IE DUB,Absolute emission reduction,2006,2030,40,percent,https://www.dublincity.ie/residential/environment/dublin-city-councils-climate-change-action-plan-2019-2024/dublin-city-council-climate-action-plan-2019-2024,net_zero_tracker
-net_zero_tracker:IT BLQ:2030,IT BLQ,Absolute emission reduction,2005,2030,40,percent,https://iclei-europe.org/member-in-the-spotlight/previous/bologna-italy/,net_zero_tracker
-net_zero_tracker:IT CTA:2030,IT CTA,Absolute emission reduction,2011,2030,40,percent,https://www.comune.catania.it/informazioni/cstampa/default.aspx?cs=32678,net_zero_tracker
-net_zero_tracker:IT GOA:2030,IT GOA,Absolute emission reduction,2005,2030,40,percent,nan,net_zero_tracker
-net_zero_tracker:IT PMO:2050,IT PMO,Absolute emission reduction,1990,2050,30,percent,nan,net_zero_tracker
-net_zero_tracker:IT VRN:2030,IT VRN,Absolute emission reduction,2006,2030,40,percent,nan,net_zero_tracker
-net_zero_tracker:JP NGO:2050,JP NGO,Absolute emission reduction,1990,2050,80,percent,https://www.city.nagoya.jp/kankyo/page/0000103019.html,net_zero_tracker
-net_zero_tracker:MX LEN:2030,MX LEN,Absolute emission reduction,2017,2030,58,percent,https://leon.gob.mx/modulos/img/adjuntos/adjuntos-646.pdf,net_zero_tracker
-net_zero_tracker:PT OPO:2030,PT OPO,Absolute emission reduction,2004,2030,50,percent,https://www.themayor.eu/en/a/view/porto-s-path-towards-cutting-greenhouse-gas-emission-5216,net_zero_tracker
-net_zero_tracker:SE GOT:2050,SE GOT,Absolute emission reduction,1990,2050,80,percent,https://carbonn.org/uploads/tx_carbonndata/Climate%20Programme_%20Folder.pdf,net_zero_tracker
-net_zero_tracker:TW KHH:2050,TW KHH,Absolute emission reduction,2005,2050,80,percent,https://www.climate-chance.org/wp-content/uploads/2020/04/synthesis-report-2019-local-action-book-case-kaohsiung_korea-p74.pdf,net_zero_tracker
-net_zero_tracker:US BNA:2050,US BNA,Absolute emission reduction,2014,2050,80,percent,https://www.nashville.gov/departments/mayor/news/mayor-cooper-announces-multiple-initiatives-combat-climate-change-and-promote,net_zero_tracker
-net_zero_tracker:US CHI:2040,US CHI,Absolute emission reduction,2017,2040,62,percent,https://www.chicago.gov/content/dam/city/sites/climate-action-plan/documents/CHICAGO_CAP_20220429.pdf,net_zero_tracker
-net_zero_tracker:US CLE:2050,US CLE,Absolute emission reduction,2010,2050,80,percent,https://drive.google.com/file/d/1Z3234sMp7S7MjaXvMgcZtcAaYs4x2oHE/view,net_zero_tracker
-net_zero_tracker:US CON:2050,US CON,Absolute emission reduction,2008,2050,80,percent,https://concordma.gov/DocumentCenter/View/25318/Sustainable-Concord-Climate-Action-and-Resilience-Plan-2020?bidId=,net_zero_tracker
-net_zero_tracker:US COS:2050,US COS,Absolute emission reduction,2005,2050,90,percent,https://leg.colorado.gov/sites/default/files/2021a_1266_signed.pdf,net_zero_tracker
-net_zero_tracker:US CVG:2050,US CVG,Absolute emission reduction,2006,2050,84,percent,https://www.cincinnati-oh.gov/sites/oes/assets/File/2018%20Green%20Cincinnati%20Plan(1).pdf,net_zero_tracker
-net_zero_tracker:US FAT:2050,US FAT,Absolute emission reduction,1990,2050,80,percent,https://www.fresno.gov/darm/wp-content/uploads/sites/10/2020/03/Appendix_G-GHG_Reduction_Plan_Update.pdf,net_zero_tracker
-net_zero_tracker:US LUI:2050,US LUI,Absolute emission reduction,2016,2050,80,percent,https://louisvilleky.gov/sustainability/document/ghgerpfinaldraft202004220pdf,net_zero_tracker
-net_zero_tracker:US MEM:2050,US MEM,Absolute emission reduction,2016,2050,71,percent,https://shelbycountytn.gov/DocumentCenter/View/37431/Memphis-Area-Climate-Action-Plan-2019-FINAL_4_JANUARY-2020,net_zero_tracker
-net_zero_tracker:US MES:2050,US MES,Absolute emission reduction,2006,2050,80,percent,https://www2.minneapolismn.gov/government/programs-initiatives/climate/climate-action-goals/greenhouse-gas-emissions-reductions/,net_zero_tracker
-net_zero_tracker:US ORL:2040,US ORL,Absolute emission reduction,2007,2040,90,percent,https://www.orlando.gov/files/sharedassets/public/departments/sustainability/2018_orlando_communityactionplan.pdf,net_zero_tracker
-net_zero_tracker:US PDX:2050,US PDX,Absolute emission reduction,1990,2050,80,percent,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5ab410faa2f42204838f7990/5ad0e40c74c4837def5d292e/files/CAP-2015_june30-2015_web.pdf?1565172676,net_zero_tracker
-net_zero_tracker:US PIT:2050,US PIT,Absolute emission reduction,2003,2050,80,percent,https://apps.pittsburghpa.gov/redtail/images/7101_Pittsburgh_Climate_Action_Plan_3.0.pdf,net_zero_tracker
-net_zero_tracker:US ROC:2030,US ROC,Absolute emission reduction,2010,2030,40,percent,https://www.cityofrochester.gov/climateactionplan/,net_zero_tracker
-net_zero_tracker:US SJC:2050,US SJC,Absolute emission reduction,1990,2050,80,percent,https://www.sanjoseca.gov/your-government/department-directory/planning-building-code-enforcement/planning-division/environmental-planning/greenhouse-gas-reduction-strategy,net_zero_tracker
-net_zero_tracker:AR BUE:2030,AR BUE,Absolute emission reduction,2015,2030,52,percent,https://www.buenosaires.gob.ar/sites/gcaba/files/pac_resumen_ejecutivo_esp_0.pdf,net_zero_tracker
-net_zero_tracker:AU MEL:2025,AU MEL,Absolute emission reduction,2015,2025,10,percent,https://www.melbourne.vic.gov.au/sitecollectiondocuments/climate-change-mitigation-strategy-2050.pdf,net_zero_tracker
-net_zero_tracker:BG SOF:2020,BG SOF,Absolute emission reduction,2007,2020,22,percent,https://www.ebrdgreencities.com/assets/Uploads/PDF/7181e1a1c8/Sofia-GCAP_ENG.pdf,net_zero_tracker
-net_zero_tracker:BR BHZ:2030,BR BHZ,Absolute emission reduction,2007,2030,20,percent,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
-net_zero_tracker:BR CPS:2025,BR CPS,Absolute emission reduction,2016,2025,5,percent,https://bibliotecajuridica.campinas.sp.gov.br/index/visualizaroriginal/id/136363,net_zero_tracker
-net_zero_tracker:BR FOR:2030,BR FOR,Absolute emission reduction,2014,2030,30,percent,https://americadosul.iclei.org/wp-content/uploads/sites/78/2021/07/30-plac-fortaleza-final-ingles.pdf,net_zero_tracker
-net_zero_tracker:BR REC:2030,BR REC,Absolute emission reduction,2017,2030,30,percent,https://americadosul.iclei.org/wp-content/uploads/sites/78/2021/07/30-plac-recife-final-ingles.pdf,net_zero_tracker
-net_zero_tracker:BR RIO:2030,BR RIO,Absolute emission reduction,2017,2030,20,percent,https://www.citiesoftomorrow.eu/sites/default/files/documents/Executive_Summary_finalok.pdf,net_zero_tracker
-net_zero_tracker:BR SAO:2020,BR SAO,Absolute emission reduction,2005,2020,20,percent,https://smastr16.blob.core.windows.net/home/2021/10/cop26_english.pdf,net_zero_tracker
-net_zero_tracker:BR SSA:2024,BR SSA,Absolute emission reduction,2018,2024,15,percent,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5c8ab5851647e100801756a3/60abe3e2795a8b00a674dd75/files/PMAMC_Ebook_ingles.pdf?1621877739,net_zero_tracker
-net_zero_tracker:CA CAL:2030,CA CAL,Absolute emission reduction,2005,2030,40,percent,https://www.calgary.ca/content/dam/www/uep/esm/documents/esm-documents/climate-resilience-strategy-and-action-plans-annual-report-2020.pdf,net_zero_tracker
-net_zero_tracker:CA OTT:2025,CA OTT,Absolute emission reduction,2012,2025,43,percent,https://documents.ottawa.ca/sites/documents/files/climate_change_mplan_en.pdf,net_zero_tracker
-net_zero_tracker:CA WNP:2030,CA WNP,Absolute emission reduction,2011,2030,20,percent,https://winnipeg.ca/sustainability/PublicEngagement/ClimateActionPlan/pdfs/CW_Climate-Action-Plan.pdf,net_zero_tracker
-net_zero_tracker:CO BOG:2030,CO BOG,Relative emission reduction,2030,2030,50,percent,https://climateaction.unfccc.int/views/stakeholder-details.html?id=11180,net_zero_tracker
-net_zero_tracker:CZ PRG:2030,CZ PRG,Absolute emission reduction,2010,2030,45,percent,https://klima.praha.eu/DATA/Dokumenty/Klimaplan_2109_15_online_LOWRES_final2.pdf,net_zero_tracker
-net_zero_tracker:DE BER:2030,DE BER,Absolute emission reduction,1990,2030,70,percent,https://gesetze.berlin.de/bsbe/document/jlr-EWendGBErahmen,net_zero_tracker
-net_zero_tracker:DE EEN:2030,DE EEN,Absolute emission reduction,1990,2030,60,percent,"https://www.essen.de/leben/umwelt/luft/treibhausgas_bilanz.de.html#:~:text=August%202020%20per%20Ratsbeschluss%20nachgesch%C3%A4rft,2040%20um%2085%20%25%20gegen%C3%BCber%201990.",net_zero_tracker
-net_zero_tracker:DE ESS:2030,DE ESS,Absolute emission reduction,1990,2030,60,percent,"https://www.essen.de/leben/umwelt/luft/treibhausgas_bilanz.de.html#:~:text=August%202020%20per%20Ratsbeschluss%20nachgesch%C3%A4rft,2040%20um%2085%20%25%20gegen%C3%BCber%201990.",net_zero_tracker
-net_zero_tracker:DE HAM:2030,DE HAM,Absolute emission reduction,1990,2030,70,percent,https://www.hamburg.de/contentblob/13899086/749a6e50662c96eee81d370f1b0cb631/data/d-first-revision-hamburg-climate-plan.pdf,net_zero_tracker
-net_zero_tracker:DE ONU:2030,DE ONU,Absolute emission reduction,1990,2030,60,percent,"https://www.essen.de/leben/umwelt/luft/treibhausgas_bilanz.de.html#:~:text=August%202020%20per%20Ratsbeschluss%20nachgesch%C3%A4rft,2040%20um%2085%20%25%20gegen%C3%BCber%201990.",net_zero_tracker
-net_zero_tracker:DE STR:2030,DE STR,Absolute emission reduction,2019,2030,65,percent,https://www.stuttgart.de/leben/umwelt/energie/,net_zero_tracker
-net_zero_tracker:EC UIO:2030,EC UIO,Absolute emission reduction,2030,2030,43,percent,http://www.quitoambiente.gob.ec/images/Secretaria_Ambiente/Cambio_Climatico/plan_accion_climatico_quito_2020/Folleto%20Resumen%20PACQ01_mar_21.pdf,net_zero_tracker
-net_zero_tracker:ES BCN:2030,ES BCN,Absolute emission reduction,2005,2030,45,percent,https://www.barcelona.cat/barcelona-pel-clima/sites/default/files/documents/climate_plan_maig.pdf,net_zero_tracker
-net_zero_tracker:ES MAD:2030,ES MAD,Absolute emission reduction,1990,2030,65,percent,https://www.madrid.es/UnidadesDescentralizadas/Sostenibilidad/EspeInf/EnergiayCC/06Divulgaci%C3%B3n/6cDocumentacion/6cNHRNeutral/Ficheros/RoadmapENG.pdf,net_zero_tracker
-net_zero_tracker:ES VLC:2030,ES VLC,Absolute emission reduction,2007,2030,40,percent,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
-net_zero_tracker:ET ADD:2030,ET ADD,Relative emission reduction,2030,2030,41,percent,https://addisenviroment.gov.et/wp-content/uploads/2021/10/C-40-September-14-compressed.pdf,net_zero_tracker
-net_zero_tracker:FR BOD:2020,FR BOD,Absolute emission reduction,2007,2020,25,percent,https://en.calameo.com/read/0014801211e68b0f697d0,net_zero_tracker
-net_zero_tracker:FR GNB:2030,FR GNB,Absolute emission reduction,2005,2030,50,percent,https://www.grenoblealpesmetropole.fr/cms_viewFile.php?idtf=7126&path=Strategie-et-plan-d-actions.pdf,net_zero_tracker
-net_zero_tracker:FR NTE:2030,FR NTE,Absolute emission reduction,2003,2030,50,percent,https://metropole.nantes.fr/territoire-institutions/projet/ambitions-territoire/33-engagements-pour-la-transitio,net_zero_tracker
-net_zero_tracker:FR PAR:2030,FR PAR,Absolute emission reduction,2004,2030,50,percent,"https://www.c40knowledgehub.org/s/article/Paris-Climate-Action-Plan-Towards-a-carbon-neutral-city-and-100-renewable-energy?language=en_US#:~:text=By%202030%2C%20an%20operational%20action,100%25%20reliant%20on%20renewable%20energy.",net_zero_tracker
-net_zero_tracker:GB GLW:2020,GB GLW,Absolute emission reduction,2006,2020,30,percent,https://www.glasgow.gov.uk/CHttpHandler.ashx?id=50623&p=0,net_zero_tracker
-net_zero_tracker:GB MNC:2025,GB MNC,Absolute emission reduction,2020,2025,50,percent,https://www.manchesterclimate.com/sites/default/files/Manchester%20Climate%20Change%20Framework%202020-25.pdf,net_zero_tracker
-net_zero_tracker:GH ACC:2030,GH ACC,Absolute emission reduction,2020,2030,50,percent,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5ab410faa2f42204838f7990/5ab5605ea2f4220acf45cfa6/files/Accra_Climate_Action_Plan.pdf?1603293785,net_zero_tracker
-net_zero_tracker:GR SKG:2020,GR SKG,Absolute emission reduction,2011,2020,20,percent,https://resilientcitiesnetwork.org/downloadable_resources/Network/Thessaloniki-Resilience-Strategy-English.pdf,net_zero_tracker
-net_zero_tracker:HK HKG:2035,HK HKG,Absolute emission reduction,2005,2035,50,percent,https://www.climateready.gov.hk/files/pdf/CAP2050_booklet_en.pdf,net_zero_tracker
-net_zero_tracker:HR ZAG:2020,HR ZAG,Absolute emission reduction,2008,2020,21,percent,https://balkangreenenergynews.com/zagreb-adopts-first-sustainable-energy-and-climate-action-plan-in-croatia/,net_zero_tracker
-net_zero_tracker:HU BUD:2030,HU BUD,Absolute emission reduction,2015,2030,40,percent,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
-net_zero_tracker:IT BLQ:2020,IT BLQ,Absolute emission reduction,2005,2020,21,percent,https://iclei-europe.org/member-in-the-spotlight/previous/bologna-italy/,net_zero_tracker
-net_zero_tracker:IT CTA:2020,IT CTA,Absolute emission reduction,2011,2020,22,percent,https://www.comune.catania.it/informazioni/cstampa/default.aspx?cs=32678,net_zero_tracker
-net_zero_tracker:IT GOA:2020,IT GOA,Absolute emission reduction,2005,2020,23,percent,nan,net_zero_tracker
-net_zero_tracker:IT PMO:2020,IT PMO,Absolute emission reduction,1990,2020,22,percent,nan,net_zero_tracker
-net_zero_tracker:IT VRN:2020,IT VRN,Absolute emission reduction,2006,2020,20,percent,nan,net_zero_tracker
-net_zero_tracker:JO AMM:2030,JO AMM,Absolute emission reduction,2014,2030,40,percent,https://www.amman.jo/site_doc/climate.pdf,net_zero_tracker
-net_zero_tracker:JP HMM:2030,JP HMM,Absolute emission reduction,2013,2030,30,percent,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
-net_zero_tracker:JP KKJ:2030,JP KKJ,Absolute emission reduction,2013,2030,30,percent,https://www.city.kitakyushu.lg.jp/kankyou/00200196.html,net_zero_tracker
-net_zero_tracker:JP KWS:2030,JP KWS,Absolute emission reduction,2013,2030,20,percent,https://www.city.kawasaki.jp/300/page/0000121670.html,net_zero_tracker
-net_zero_tracker:JP MYJ:2030,JP MYJ,Absolute emission reduction,2013,2030,27,percent,https://www.city.matsuyama.ehime.jp/shisei/machizukuri/kankyoumodel/modelkeikaku.html,net_zero_tracker
-net_zero_tracker:JP NGO:2030,JP NGO,Absolute emission reduction,2013,2030,27,percent,https://www.city.nagoya.jp/kankyo/page/0000103019.html,net_zero_tracker
-net_zero_tracker:JP SAK:2030,JP SAK,Absolute emission reduction,2013,2030,27,percent,https://www.city.sakai.lg.jp/shisei/gyosei/shishin/kankyo/torikumi/env_strat.html,net_zero_tracker
-net_zero_tracker:JP SGH:2030,JP SGH,Absolute emission reduction,2013,2030,46,percent,https://www.city.sagamihara.kanagawa.jp/kurashi/kankyo/plan/1023953/index.html,net_zero_tracker
-net_zero_tracker:JP SPK:2030,JP SPK,Absolute emission reduction,2016,2030,55,percent,https://www.city.sapporo.jp/kankyo/ondanka/kikouhendou_plan2020/index.html,net_zero_tracker
-net_zero_tracker:JP UKB:2030,JP UKB,Absolute emission reduction,2013,2030,34,percent,https://www.city.kobe.lg.jp/documents/4411/20201209_2050zero.pdf,net_zero_tracker
-net_zero_tracker:JP YOK:2030,JP YOK,Absolute emission reduction,2014,2030,30,percent,https://www.city.yokohama.lg.jp/kurashi/machizukuri-kankyo/ondanka/jikkou/,net_zero_tracker
-net_zero_tracker:KE NBO:2035,KE NBO,Relative emission reduction,2035,2035,44,percent,https://cdn.nation.co.ke/downloads/Nairobi-City-Climate-Action-2021.pdf,net_zero_tracker
-net_zero_tracker:KR SEL:2030,KR SEL,Absolute emission reduction,2005,2030,40,percent,https://www.si.re.kr/si_download/63602/27895,net_zero_tracker
-net_zero_tracker:LV RIX:2020,LV RIX,Absolute emission reduction,1990,2020,55,percent,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
-net_zero_tracker:MX GDL:2030,MX GDL,Absolute emission reduction,2017,2030,40,percent,https://transparencia.info.jalisco.gob.mx/sites/default/files/Plan%20de%20acci%C3%B3n%20clim%C3%A1tica.pdf,net_zero_tracker
-net_zero_tracker:MY KUL:2030,MY KUL,Relative emission reduction,2030,2030,40,percent,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5ab410faa2f42204838f7990/5b4e04e374782004ac0c8ac2/files/C40_KLCAP2050_viewing-only-MR-single.pdf?1626096224,net_zero_tracker
-net_zero_tracker:NG ABV:2030,NG ABV,Absolute emission reduction,2030,2030,20,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Nigeria%20First/NIGERIA%202021%20NDC-FINAL.pdf,net_zero_tracker
-net_zero_tracker:NG LOS:2035,NG LOS,Absolute emission reduction,2020,2035,45,percent,https://moelagos.gov.ng/wp-content/uploads/2021/09/C40-Lagos_Indesign-Document-Full-Report-Revert-2_Update-2.pdf,net_zero_tracker
-net_zero_tracker:NL AMS:2030,NL AMS,Absolute emission reduction,1990,2030,55,percent,https://www.amsterdam.nl/en/policy/sustainability/policy-climate-neutrality/,net_zero_tracker
-net_zero_tracker:NL RTM:2030,NL RTM,Absolute emission reduction,1990,2030,49,percent,https://www.010duurzamestad.nl/wat-wij-doen/Rotterdamse-klimaataanpak-mei-2019.pdf,net_zero_tracker
-net_zero_tracker:NO OSL:2023,NO OSL,Absolute emission reduction,2009,2023,52,percent,https://tinyurl.com/2kxrny69,net_zero_tracker
-net_zero_tracker:NZ AKL:2030,NZ AKL,Absolute emission reduction,2016,2030,50,percent,https://www.aucklandcouncil.govt.nz/plans-projects-policies-reports-bylaws/our-plans-strategies/topic-based-plans-strategies/environmental-plans-strategies/aucklands-climate-plan/Documents/auckland-climate-plan.pdf,net_zero_tracker
-net_zero_tracker:PT OPO:2020,PT OPO,Absolute emission reduction,2004,2020,45,percent,https://www.themayor.eu/en/a/view/porto-s-path-towards-cutting-greenhouse-gas-emission-5216,net_zero_tracker
-net_zero_tracker:SN DKR:2030,SN DKR,Relative emission reduction,2030,2030,25,percent,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5c8ab5851647e100801756a3/60dadeb05761d600a57c9345/files/C40_Dakar_English_Final.pdf?1624956592,net_zero_tracker
-net_zero_tracker:TR AYT:2030,TR AYT,Absolute emission reduction,2019,2030,40,percent,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
-net_zero_tracker:TR IST:2030,TR IST,Relative emission reduction,2030,2030,33,percent,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
-net_zero_tracker:TR IZM:2030,TR IZM,Absolute emission reduction,2018,2030,40,percent,nan,net_zero_tracker
-net_zero_tracker:TW KHH:2030,TW KHH,Absolute emission reduction,2005,2030,50,percent,https://www.climate-chance.org/wp-content/uploads/2020/04/synthesis-report-2019-local-action-book-case-kaohsiung_korea-p74.pdf,net_zero_tracker
-net_zero_tracker:TW TNN:2030,TW TNN,Absolute emission reduction,2005,2030,20,percent,https://www.tainan.gov.tw/en/News_Content.aspx?n=13205&sms=13686&s=7768548,net_zero_tracker
-net_zero_tracker:TZ DAR:2030,TZ DAR,Relative emission reduction,2030,2030,29,percent,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5c8ab5851647e100801756a3/623af4b0bf8bcc8b7c5a7d76/files/Dar_CAP_English_Version_Final_16_Dec_2021.pdf?1648030896,net_zero_tracker
-net_zero_tracker:US BNA:2030,US BNA,Absolute emission reduction,2014,2030,40,percent,https://www.nashville.gov/departments/mayor/news/mayor-cooper-announces-multiple-initiatives-combat-climate-change-and-promote,net_zero_tracker
-net_zero_tracker:US CLE:2030,US CLE,Absolute emission reduction,2010,2030,40,percent,https://drive.google.com/file/d/1Z3234sMp7S7MjaXvMgcZtcAaYs4x2oHE/view,net_zero_tracker
-net_zero_tracker:US CON:2030,US CON,Absolute emission reduction,2008,2030,45,percent,https://concordma.gov/DocumentCenter/View/25318/Sustainable-Concord-Climate-Action-and-Resilience-Plan-2020?bidId=,net_zero_tracker
-net_zero_tracker:US COS:2025,US COS,Absolute emission reduction,2005,2025,26,percent,https://leg.colorado.gov/sites/default/files/2021a_1266_signed.pdf,net_zero_tracker
-net_zero_tracker:US CVG:2028,US CVG,Absolute emission reduction,2006,2028,40,percent,https://www.cincinnati-oh.gov/sites/oes/assets/File/2018%20Green%20Cincinnati%20Plan(1).pdf,net_zero_tracker
-net_zero_tracker:US FAT:2030,US FAT,Absolute emission reduction,1990,2030,40,percent,https://www.fresno.gov/darm/wp-content/uploads/sites/10/2020/03/Appendix_G-GHG_Reduction_Plan_Update.pdf,net_zero_tracker
-net_zero_tracker:US MEM:2035,US MEM,Absolute emission reduction,2016,2035,51,percent,https://shelbycountytn.gov/DocumentCenter/View/37431/Memphis-Area-Climate-Action-Plan-2019-FINAL_4_JANUARY-2020,net_zero_tracker
-net_zero_tracker:US MES:2025,US MES,Absolute emission reduction,2006,2025,30,percent,https://www2.minneapolismn.gov/government/programs-initiatives/climate/climate-action-goals/greenhouse-gas-emissions-reductions/,net_zero_tracker
-net_zero_tracker:US PDX:2030,US PDX,Absolute emission reduction,1990,2030,40,percent,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5ab410faa2f42204838f7990/5ad0e40c74c4837def5d292e/files/CAP-2015_june30-2015_web.pdf?1565172676,net_zero_tracker
-net_zero_tracker:US PIT:2023,US PIT,Absolute emission reduction,2003,2023,20,percent,https://apps.pittsburghpa.gov/redtail/images/7101_Pittsburgh_Climate_Action_Plan_3.0.pdf,net_zero_tracker
-net_zero_tracker:US ROC:2020,US ROC,Absolute emission reduction,2010,2020,20,percent,https://www.cityofrochester.gov/climateactionplan/,net_zero_tracker
-net_zero_tracker:US SJC:2030,US SJC,Absolute emission reduction,1990,2030,36,percent,https://www.sanjoseca.gov/your-government/department-directory/planning-building-code-enforcement/planning-division/environmental-planning/greenhouse-gas-reduction-strategy,net_zero_tracker
-net_zero_tracker:VN HAN:2030,VN HAN,Absolute emission reduction,2020,2030,15,percent,https://en.vietnamplus.vn/hanoi-aims-to-reduce-greenhouse-gas-emissions/191063.vnp,net_zero_tracker
-net_zero_tracker:ZA DUR:2030,ZA DUR,Absolute emission reduction,2015,2030,40,percent,https://tinyurl.com/2zdlc28c,net_zero_tracker
-net_zero_tracker:ZA JNB:2030,ZA JNB,Absolute emission reduction,2016,2030,25,percent,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5ab410faa2f42204838f7990/5ab5614aa2f4220acf45cfb8/files/City_of_Johannesburg_-_CAP-lores-compressed.pdf?1623066563,net_zero_tracker
-net_zero_tracker:ZA PRY:2030,ZA PRY,Absolute emission reduction,2015,2030,15,percent,https://www.tshwane.gov.za/sites/Council/Ofiice-Of-The-Executive-Mayor/Climate%20Action/CAP_EXECUTIVE%20SUMMARY%20REPORT%20no%20marks.pdf,net_zero_tracker
-net_zero_tracker:1FRVQX2CRLGC1XLP5727:2025,1FRVQX2CRLGC1XLP5727,Relative emission reduction,2019,2025,50,percent,https://www.marathonoil.com/sustainability/environment/climate-change/,net_zero_tracker
-net_zero_tracker:2138007JNS19JHNA2336:2030,2138007JNS19JHNA2336,Absolute emission reduction,2014,2030,55,percent,https://www.sgs.com/en/news/2018/04/sgs-becomes-one-of-100-companies-to-commit-to-science-based-targets-for-greenhouse-gas-emissions,net_zero_tracker
-net_zero_tracker:2138008J191VLSGY5A09:2030,2138008J191VLSGY5A09,Absolute emission reduction,2015,2030,38,percent,https://ucb-s3-storage.s3.eu-central-1.amazonaws.com/2021_UCB_Integrated_Annual_Report_ENG_86e2c54bdc.pdf,net_zero_tracker
-net_zero_tracker:213800M993ICXOMBCP87:2020,213800M993ICXOMBCP87,Absolute emission reduction,2016,2020,50,percent,https://www.sjp.co.uk/~/media/Files/S/SJP-Corp/document-library/reports/2021/SJP_CDP-Report_April2021.pdf,net_zero_tracker
-net_zero_tracker:353800D83H0V3ZV1SV24:2050,353800D83H0V3ZV1SV24,Absolute emission reduction,2010,2050,90,percent,https://www.globalsuzuki.com/corporate/csr_environment/intro/vision.html,net_zero_tracker
-net_zero_tracker:353800H2UB5ZEZRZQC02:2030,353800H2UB5ZEZRZQC02,Absolute emission reduction,2014,2030,40,percent,https://www.mitsubishi-motors.com/en/sustainability/pdf/report-2020/sustainability2020_e.pdf?201214,net_zero_tracker
-net_zero_tracker:353800JX1R4582QVK932:2050,353800JX1R4582QVK932,Absolute emission reduction,2018,2050,80,percent,https://www.terumo.com/sustainability/reports/pdf/SustainabilityDataBook_2020_E.pdf,net_zero_tracker
-net_zero_tracker:353800K1RXV3E3JAE812:2050,353800K1RXV3E3JAE812,Absolute emission reduction,2010,2050,90,percent,https://www.mazda.com/en/csr/environment/sustainable/,net_zero_tracker
-net_zero_tracker:353800KOFMRGOXSJ5Z65:2050,353800KOFMRGOXSJ5Z65,Absolute emission reduction,2017,2050,87,percent,https://www.mec.co.jp/e/sustainability/activities/environment/climate-change/,net_zero_tracker
-net_zero_tracker:353800UT0TLROREPIC92:2030,353800UT0TLROREPIC92,Absolute emission reduction,2018,2030,50,percent,https://www.ajinomoto.com/sustainability/materiality/climate_change.php,net_zero_tracker
-net_zero_tracker:353800XGIU2IHQGC9504:2030,353800XGIU2IHQGC9504,Absolute emission reduction,2015,2030,37,percent,https://www.daiichisankyo.com/our_stories/detail/index_4090.html,net_zero_tracker
-net_zero_tracker:3BNYRYQHD39K4LCKQF12:2030,3BNYRYQHD39K4LCKQF12,Relative emission reduction,2014,2030,30,percent,https://www.marathonpetroleum.com/Sustainability/Lowering-Carbon-Intensity/,net_zero_tracker
-net_zero_tracker:3PPKBHUG1HD6BO7RNR87:2050,3PPKBHUG1HD6BO7RNR87,Absolute emission reduction,2005,2050,50,percent,https://www.textron.com/assets/CR/2019/ProductSustainabilityHighlights.html,net_zero_tracker
-net_zero_tracker:41BNNE1AFPNAZELZ6K07:2030,41BNNE1AFPNAZELZ6K07,Absolute emission reduction,2019,2030,50,percent,https://publish-p33711-e119406.adobeaemcloud.com/content/dam/site/company/csr/doc/2019_Sustainability_F.pdf.coredownload.inline.pdf,net_zero_tracker
-net_zero_tracker:529900FNDVTQJOVVPZ19:2030,529900FNDVTQJOVVPZ19,Absolute emission reduction,2020,2030,40,percent,https://www.thalesgroup.com/fr/group/journaliste/press-release/thales-comment-hautes-technologies-peuvent-reduire-court-terme,net_zero_tracker
-net_zero_tracker:529900YT4O5S0LCXWD54:2050,529900YT4O5S0LCXWD54,Absolute emission reduction,2013,2050,85,percent,https://www.obayashi.co.jp/en/sustainability/environment/tcfd.html,net_zero_tracker
-net_zero_tracker:5493000CGCQY2OQU7669:2030,5493000CGCQY2OQU7669,Absolute emission reduction,2019,2030,50,percent,https://www.jabil.com/about-us/sustainability/our-operations-and-resources.html,net_zero_tracker
-net_zero_tracker:5493007JDSMX8Z5Z1902:2030,5493007JDSMX8Z5Z1902,Absolute emission reduction,2020,2030,42,percent,https://www.campbellsoupcompany.com/newsroom/news/reducing-greenhouse-gas-emissions-in-our-operations/,net_zero_tracker
-net_zero_tracker:5493008C12PZMWP3WY03:2034,5493008C12PZMWP3WY03,Absolute emission reduction,2019,2034,42,percent,https://www.kcsouthern.com/corporate-responsibility/our-commitment/KCS-2019-Sustainability-Report.pdf,net_zero_tracker
-net_zero_tracker:5493008FFSI8SQ74AT93:2050,5493008FFSI8SQ74AT93,Absolute emission reduction,2013,2050,80,percent,https://global.kawasaki.com/en/corp/sustainability/environment/20_houkokusyo.pdf,net_zero_tracker
-net_zero_tracker:549300CSY4INHEHQQT13:2030,549300CSY4INHEHQQT13,Absolute emission reduction,2014,2030,30,percent,https://www.kubota.com/sustainability/environment/ghg/index.html,net_zero_tracker
-net_zero_tracker:549300D8GOWWH0SJB189:2030,549300D8GOWWH0SJB189,Absolute emission reduction,2005,2030,90,percent,https://www.nisource.com/docs/librariesprovider2/sustainability-archives/2021/2021-cdp-climate-change-response.pdf?sfvrsn=4,net_zero_tracker
-net_zero_tracker:549300H5LSF8DP3RIJ34:2031,549300H5LSF8DP3RIJ34,Relative emission reduction,2018,2031,30,percent,https://www.tel.com/csr/environment/,net_zero_tracker
-net_zero_tracker:549300QD81EPLH4NUQ92:2040,549300QD81EPLH4NUQ92,Absolute emission reduction,2015,2040,90,percent,https://www.results.philips.com/publications/ar20,net_zero_tracker
-net_zero_tracker:549300QQXOOYEF89IC56:2030,549300QQXOOYEF89IC56,Absolute emission reduction,2020,2030,42,percent,https://www.responsibilityreports.com/HostedData/ResponsibilityReports/PDF/NASDAQ_WDC_2021.pdf,net_zero_tracker
-net_zero_tracker:549300RPTUOIXG4LIH86:2030,549300RPTUOIXG4LIH86,Absolute emission reduction,2011,2030,30,percent,https://www.walgreensbootsalliance.com/sites/www/files/2021-01/WBA_CDP_Climate_Change_Questionnaire_2020_26%20Aug.pdf,net_zero_tracker
-net_zero_tracker:549300XTO5VR8SKV1V74:2035,549300XTO5VR8SKV1V74,Absolute emission reduction,2011,2035,100,percent,https://www.valero.com/sites/default/files/valero-documents/2020%20SRR_Web%20Version_Spreads%207-26.pdf,net_zero_tracker
-net_zero_tracker:5T547R1474YC9HOD8Q74:2025,5T547R1474YC9HOD8Q74,Absolute emission reduction,2016,2025,35,percent,https://www.waters.com/webassets/cms/category/docs/Sustainability_Report_2020.pdf,net_zero_tracker
-net_zero_tracker:6EY4K7ZMF9UX1CU6KC79:2030,6EY4K7ZMF9UX1CU6KC79,Absolute emission reduction,2015,2030,50,percent,https://www.xilinx.com/content/dam/xilinx/publications/about/xilinx-cdp-climate-change-2021.pdf,net_zero_tracker
-net_zero_tracker:787RXPR0UX0O0XUXPZ81:2030,787RXPR0UX0O0XUXPZ81,Absolute emission reduction,2021,2030,65,percent,https://news.nike.com/news/our-carbon-footprint-and-our-next-steps,net_zero_tracker
-net_zero_tracker:894500ZRIX9K13RHXR17:2030,894500ZRIX9K13RHXR17,Absolute emission reduction,2019,2030,35,percent,https://www.te.com/usa-en/about-te/corporate-responsibility.html,net_zero_tracker
-net_zero_tracker:8MYN82XMYQH89CTMTH67:2030,8MYN82XMYQH89CTMTH67,Absolute emission reduction,2019,2030,46,percent,https://www.anthemcorporateresponsibility.com/environmental-policy-and-commitments,net_zero_tracker
-net_zero_tracker:CZ72ZHBVKZXQRV3XFE26:2025,CZ72ZHBVKZXQRV3XFE26,Relative emission reduction,2019,2025,33,percent,https://sustainability.ovintiv.com/environment/emissions-and-climate-change/,net_zero_tracker
-net_zero_tracker:CZ72ZHBVKZXQRV3XFE26:2030,CZ72ZHBVKZXQRV3XFE26,Absolute emission reduction,2017,2030,30,percent,https://www.otsuka.com/en/csr/environment/climate.html,net_zero_tracker
-net_zero_tracker:D3W7PCXCBRQLL17DZ313:2050,D3W7PCXCBRQLL17DZ313,Absolute emission reduction,2005,2050,50,percent,https://www.wfscorp.com/en/wfscorp/docs/WFS-2019-Sustainability-Report.pdf,net_zero_tracker
-net_zero_tracker:DYTQ8KRTKO7Y2BVU5K74:2030,DYTQ8KRTKO7Y2BVU5K74,Absolute emission reduction,2018,2030,30,percent,https://www.keurigdrpepper.com/content/dam/keurig-brand-sites/kdp/files/KDP-CR-Report-2021.pdf,net_zero_tracker
-net_zero_tracker:FR5LCKFTG8054YNNRU85:2035,FR5LCKFTG8054YNNRU85,Absolute emission reduction,2015,2035,50,percent,https://www.abbvie.com/content/dam/abbvie-dotcom/uploads/PDFs/AbbVie-Environmental_Stewardship-9.2016.pdf,net_zero_tracker
-net_zero_tracker:I9Q57JVPWHHZ3ZGBW498:2050,I9Q57JVPWHHZ3ZGBW498,Absolute emission reduction,2012,2050,100,percent,https://www.comerica.com/content/dam/comerica/en/documents/resources/about/sustainability/2020-comerica-cr-report-final.pdf,net_zero_tracker
-net_zero_tracker:LONOZNOJYIBXOHXWDB86:2050,LONOZNOJYIBXOHXWDB86,Absolute emission reduction,2015,2050,66,percent,https://betterdays.kelloggcompany.com/climate-action,net_zero_tracker
-net_zero_tracker:LZ2C6E0W5W7LQMX5ZI37:2030,LZ2C6E0W5W7LQMX5ZI37,Relative emission reduction,1990,2030,33,percent,https://www.heidelbergcement.com/de/energie-und-klimaschutz,net_zero_tracker
-net_zero_tracker:N1GZ7BBF3NP8GI976H15:2044,N1GZ7BBF3NP8GI976H15,Absolute emission reduction,2014,2044,60,percent,https://www.usbank.com/about-us-bank/community/sustainability.html,net_zero_tracker
-net_zero_tracker:NNROIXVWJ7CPSR27SV97:2021,NNROIXVWJ7CPSR27SV97,Absolute emission reduction,2020,2021,4,percent,nan,net_zero_tracker
-net_zero_tracker:QG7T915N9S0NY5UKNE63:2024,QG7T915N9S0NY5UKNE63,Absolute emission reduction,2018,2024,25,percent,https://www.synopsys.com/company/corporate-social-responsibility/environment.html,net_zero_tracker
-net_zero_tracker:RVHJWBXLJ1RFUBSY1F30:2050,RVHJWBXLJ1RFUBSY1F30,Absolute emission reduction,2005,2050,50,percent,https://www.boeing.com/resources/boeingdotcom/principles/sustainability/assets/data/2021_Boeing_Sustainability_Report.pdf,net_zero_tracker
-net_zero_tracker:WAFCR4OKGSC504WU3E95:2030,WAFCR4OKGSC504WU3E95,Absolute emission reduction,2016,2030,60,percent,https://corporate.lowes.com/sites/lowes-corp/files/2021-07/2020_CSR_FINAL.pdf,net_zero_tracker
-net_zero_tracker:0BGI85ALH27ZJP15DY16:2030,0BGI85ALH27ZJP15DY16,Absolute emission reduction,2017,2030,55,percent,https://www.ball.com/na/vision/sustainability/operational-excellence/ghg-emissions,net_zero_tracker
-net_zero_tracker:0EEB8GF0W0NPCIHZX097:2030,0EEB8GF0W0NPCIHZX097,Absolute emission reduction,2018,2030,60,percent,https://publications.aecom.com/sustainable-legacies/achieve-net-zero-carbon-emissions,net_zero_tracker
-net_zero_tracker:1B4S6S7G0TW5EE83BO58:2030,1B4S6S7G0TW5EE83BO58,Absolute emission reduction,2000,2030,80,percent,https://www.aepsustainability.com/performance/report/docs/2022_AEP-Sustainability-Report.pdf,net_zero_tracker
-net_zero_tracker:1FRVQX2CRLGC1XLP5727:2021,1FRVQX2CRLGC1XLP5727,Relative emission reduction,2019,2021,30,percent,https://www.marathonoil.com/sustainability/environment/climate-change/,net_zero_tracker
-net_zero_tracker:1Z4GXXU7ZHVWFCD8TV52:2025,1Z4GXXU7ZHVWFCD8TV52,Absolute emission reduction,2015,2025,26,percent,https://www.oracle.com/assets/ccr-datasheet-3855392.pdf,net_zero_tracker
-net_zero_tracker:20S05OYHG0MQM4VUIC57:2035,20S05OYHG0MQM4VUIC57,Absolute emission reduction,2017,2035,76,percent,https://corporate.ford.com/microsites/integrated-sustainability-and-financial-report-2021/files/ir21.pdf,net_zero_tracker
-net_zero_tracker:2138001AVBSD1HSC6Z10:2030,2138001AVBSD1HSC6Z10,Absolute emission reduction,2019,2030,33,percent,https://matthey.com/en/news/2021/btc-opening,net_zero_tracker
-net_zero_tracker:2138001P49OLAEU33T68:2030,2138001P49OLAEU33T68,Absolute emission reduction,1000,2030,50,percent,https://www.thephoenixgroup.com/corporate-responsibility/environment.aspx,net_zero_tracker
-net_zero_tracker:2138007JNS19JHNA2336:2025,2138007JNS19JHNA2336,Absolute emission reduction,2014,2025,45,percent,https://www.sgs.com/en/news/2018/04/sgs-becomes-one-of-100-companies-to-commit-to-science-based-targets-for-greenhouse-gas-emissions,net_zero_tracker
-net_zero_tracker:213800FKA5MF17RJKT63:2030,213800FKA5MF17RJKT63,Absolute emission reduction,2020,2030,50,percent,https://www.bat.com/group/sites/UK__9D9KCY.nsf/vwPagesWebLive/DOAWWEKR/$file/BAT_Low_Carbon_Transition_Plan_2022.pdf,net_zero_tracker
-net_zero_tracker:213800KBMEV7I92FY281:2025,213800KBMEV7I92FY281,Absolute emission reduction,2016,2025,38,percent,https://www.kingfisher.com/en/media/news/kingfisher-news/2021/kingfisher-plc-announces-new-2025-carbon-reduction-targets---app.html,net_zero_tracker
-net_zero_tracker:213800LH1BZH3DI6G760:2025,213800LH1BZH3DI6G760,Absolute emission reduction,2019,2025,20,percent,https://www.bp.com/content/dam/bp/business-sites/en/global/corporate/pdfs/sustainability/group-reports/bp-sustainability-report-2020.pdf,net_zero_tracker
-net_zero_tracker:213800LOZA69QFDC9N34:2025,213800LOZA69QFDC9N34,Absolute emission reduction,2014,2025,34,percent,https://www.mondigroup.com/en/sustainability/sustainability-reports-and-publications/,net_zero_tracker
-net_zero_tracker:213800M993ICXOMBCP87:2025,213800M993ICXOMBCP87,Absolute emission reduction,2018,2025,50,percent,https://www.sjp.co.uk/~/media/Files/S/SJP-Corp/document-library/reports/2021/SJP_CDP-Report_April2021.pdf,net_zero_tracker
-net_zero_tracker:213800MY6QVH4FVLD628:2030,213800MY6QVH4FVLD628,Absolute emission reduction,2020,2030,30,percent,https://www.antofagasta.co.uk/investors/news/2021/antofagasta-sets-new-emissions-targets/,net_zero_tracker
-net_zero_tracker:213800TCZZU84G8Z2M70:2026,213800TCZZU84G8Z2M70,Absolute emission reduction,2021,2026,25,percent,https://www.royalmail.com/sustainability/environment/net-zero,net_zero_tracker
-net_zero_tracker:213800WFQ334R8UXUG83:2030,213800WFQ334R8UXUG83,Absolute emission reduction,2018,2030,40,percent,https://www.vinci.com/publi/vinci/extract/2021_annual_report_extract-sustainability.pdf,net_zero_tracker
-net_zero_tracker:213800X3Q9LSAKRUWY91:2030,213800X3Q9LSAKRUWY91,Absolute emission reduction,2015,2030,80,percent,https://www.kbc.com/en/corporate-sustainability/limiting-our-adverse-impact/our-own-environmental-footprint.html,net_zero_tracker
-net_zero_tracker:213800XC35KGM9NFC641:2030,213800XC35KGM9NFC641,Absolute emission reduction,2020,2030,42,percent,https://www.segro.com/responsible-segro/carbon,net_zero_tracker
-net_zero_tracker:213800YOEO5OQ72G2R82:2030,213800YOEO5OQ72G2R82,Absolute emission reduction,2018,2030,15,percent,https://www.riotinto.com/-/media/Content/Documents/Invest/Reports/Climate-Change-reports/RT-climate-report-2020.pdf?rev=c415a8138bd7408496ccb3834511abc0,net_zero_tracker
-net_zero_tracker:2572IBTT8CCZW6AU4141:2030,2572IBTT8CCZW6AU4141,Absolute emission reduction,2010,2030,50,percent,https://www.pginvestor.com/esg/environmental/climate/default.aspx,net_zero_tracker
-net_zero_tracker:2S72QS2UO2OESLG6Y829:2030,2S72QS2UO2OESLG6Y829,Absolute emission reduction,2019,2030,53,percent,https://www.verizon.com/about/news/verizon-environmental-initiatives-reduce-global-climate-impact,net_zero_tracker
-net_zero_tracker:2TGYMUGI08PO8X8L6150:2030,2TGYMUGI08PO8X8L6150,Absolute emission reduction,2020,2030,30,percent,https://www.generalmills.com/en/Responsibility/Sustainability/climate-change,net_zero_tracker
-net_zero_tracker:35380000WKGEAHEMW830:2026,35380000WKGEAHEMW830,Absolute emission reduction,2014,2026,25,percent,https://www.toyota-industries.com/investors/items/TICO%20Report%202021_EN_full_view.pdf,net_zero_tracker
-net_zero_tracker:3538000246DHJLRTUZ24:2030,3538000246DHJLRTUZ24,Absolute emission reduction,2013,2030,71,percent,https://www.fujitsu.com/global/documents/about/resources/reports/sustainabilityreport/2018-report/fujitsureport201801-e.pdf,net_zero_tracker
-net_zero_tracker:3538001KQ5SAOZSQTT44:2030,3538001KQ5SAOZSQTT44,Absolute emission reduction,2017,2030,34,percent,"https://www.engieimpact.com/insights/decarbonization-energy-sector#:~:text=In%20May%202021%2C%20ENGIE%20announced,emissions%20across%20its%20value%20chain.&text=This%20long%2Dterm%20ambition%20is,well%20below%202%C2%B0C.",net_zero_tracker
-net_zero_tracker:3538002NUIQ8JFEJNS94:2030,3538002NUIQ8JFEJNS94,Absolute emission reduction,2013,2030,75,percent,https://www.shigagin.com/pdf/investor_anuual_ar2021_all.pdf,net_zero_tracker
-net_zero_tracker:3538004IOK08PDY6I723:2031,3538004IOK08PDY6I723,Absolute emission reduction,2014,2031,50,percent,https://www.aisin.com/en/sustainability/report/pdf/aisin_ar2021_en_a4.pdf,net_zero_tracker
-net_zero_tracker:3538004LR5NXILJDHY88:2030,3538004LR5NXILJDHY88,Absolute emission reduction,2010,2030,45,percent,https://global.yamaha-motor.com/about/csr/the_environment/plan-2050/#sec-01-07,net_zero_tracker
-net_zero_tracker:3538005PGNIBTZYXAE45:2030,3538005PGNIBTZYXAE45,Absolute emission reduction,2010,2030,30,percent,https://www.tokyu.co.jp/ir/english/upload_file/m002-m002_09/Tokyu_Integratedreport_2020e.pdf,net_zero_tracker
-net_zero_tracker:35380099TCYR5FHT0A11:2030,35380099TCYR5FHT0A11,Absolute emission reduction,2013,2030,30,percent,https://www.toray.com/global/sustainability/tcfd/pdf/TCFD_report.pdf,net_zero_tracker
-net_zero_tracker:353800BRAE0QFP3ZLY22:2030,353800BRAE0QFP3ZLY22,Absolute emission reduction,1990,2030,70,percent,https://www.shimz.co.jp/en/company/csr/environment/performance/eco/,net_zero_tracker
-net_zero_tracker:353800CWW4SRGEYEB512:2030,353800CWW4SRGEYEB512,Absolute emission reduction,2017,2030,60,percent,https://www.sompo-hd.com/-/media/hd/en/files/csr/communications/pdf/2021/e_report2021.pdf?la=ja-JP,net_zero_tracker
-net_zero_tracker:353800D83H0V3ZV1SV24:2030,353800D83H0V3ZV1SV24,Absolute emission reduction,2016,2030,45,percent,https://www.globalsuzuki.com/corporate/csr_environment/intro/vision.html,net_zero_tracker
-net_zero_tracker:353800EMK32PDKS9XR54:2030,353800EMK32PDKS9XR54,Absolute emission reduction,2018,2030,30,percent,https://www.advantest.com/sustainability/pdf/E_all_IAR2020.pdf,net_zero_tracker
-net_zero_tracker:353800GBVL72LLMTYM96:2030,353800GBVL72LLMTYM96,Absolute emission reduction,2015,2030,30,percent,https://www.kirinholdings.co.jp/english/csv/env/climatechange.html,net_zero_tracker
-net_zero_tracker:353800GPI4Z3MGDGN142:2030,353800GPI4Z3MGDGN142,Absolute emission reduction,2013,2030,30,percent,https://www.asahi-kasei.com/news/2021/e210525_2.html,net_zero_tracker
-net_zero_tracker:353800HM38HFCB8RGL63:2030,353800HM38HFCB8RGL63,Absolute emission reduction,2017,2030,22,percent,https://www.kao.com/content/dam/sites/kao/www-kao-com/global/en/sustainability/pdf/klp-pr-2021-e-all.pdf,net_zero_tracker
-net_zero_tracker:353800JX1R4582QVK932:2030,353800JX1R4582QVK932,Absolute emission reduction,2018,2030,30,percent,https://www.terumo.com/sustainability/reports/pdf/SustainabilityDataBook_2020_E.pdf,net_zero_tracker
-net_zero_tracker:353800K1RXV3E3JAE812:2030,353800K1RXV3E3JAE812,Absolute emission reduction,2010,2030,50,percent,https://www.mazda.com/en/csr/environment/sustainable/,net_zero_tracker
-net_zero_tracker:353800KOFMRGOXSJ5Z65:2030,353800KOFMRGOXSJ5Z65,Absolute emission reduction,2017,2030,35,percent,https://www.mec.co.jp/e/sustainability/activities/environment/climate-change/,net_zero_tracker
-net_zero_tracker:353800KTF7EYIIYHY088:2030,353800KTF7EYIIYHY088,Absolute emission reduction,2013,2030,50,percent,https://www.tohoku-epco.co.jp/ir/report/integrated_report/pdf/tohoku_report2021en.pdf,net_zero_tracker
-net_zero_tracker:353800ND4ZKNZDYKMF33:2030,353800ND4ZKNZDYKMF33,Absolute emission reduction,2019,2030,30,percent,https://www.mitsuifudosan.co.jp/english/corporate/esg_csr/environment/05.html,net_zero_tracker
-net_zero_tracker:353800P843RLCDBLNT17:2030,353800P843RLCDBLNT17,Absolute emission reduction,2015,2030,100,percent,https://www.smth.jp/english/-/media/th/english/news/2021/E211020.pdf,net_zero_tracker
-net_zero_tracker:353800P8O843TMAZ6S09:2030,353800P8O843TMAZ6S09,Absolute emission reduction,2013,2030,40,percent,https://jp.mitsuichemicals.com/en/sustainability/mci_sustainability/climate_change/carbon_neutrality.htm,net_zero_tracker
-net_zero_tracker:353800PFUKP5ONPJNZ86:2025,353800PFUKP5ONPJNZ86,Absolute emission reduction,2013,2025,50,percent,https://www.kepco.co.jp/english/csr/,net_zero_tracker
-net_zero_tracker:353800SENYJ2DSM6PS44:2031,353800SENYJ2DSM6PS44,Absolute emission reduction,2014,2031,50,percent,https://www.jreast.co.jp/e/environment/pdf_2020/all.pdf,net_zero_tracker
-net_zero_tracker:353800UQ4BZIJTAQEG85:2030,353800UQ4BZIJTAQEG85,Absolute emission reduction,2016,2030,34,percent,https://www.unicharm.co.jp/content/dam/sites/www_unicharm_co_jp/pdf/csr-eco/report/en-ucsus2020_all_English.pdf,net_zero_tracker
-net_zero_tracker:353800UT0TLROREPIC92:2025,353800UT0TLROREPIC92,Absolute emission reduction,2018,2025,30,percent,https://www.ajinomoto.com/sustainability/materiality/climate_change.php,net_zero_tracker
-net_zero_tracker:353800VHYYADPR6MXQ47:2030,353800VHYYADPR6MXQ47,Absolute emission reduction,2019,2030,30,percent,https://www.inpex.co.jp/english/csr/climatechange/,net_zero_tracker
-net_zero_tracker:353800W25FCOFE32EM73:2030,353800W25FCOFE32EM73,Absolute emission reduction,2019,2030,50,percent,https://www.asahigroup-holdings.com/en/csr/environment/climatechange.html,net_zero_tracker
-net_zero_tracker:353800YNKX4RQUGAR072:2030,353800YNKX4RQUGAR072,Absolute emission reduction,2019,2030,29,percent,https://www.mitsubishichem-hd.co.jp/english/news_release/01139.html,net_zero_tracker
-net_zero_tracker:378900F4544561A97588:2030,378900F4544561A97588,Absolute emission reduction,2017,2030,30,percent,"https://www.sasol.com/media-centre/media-releases/sasols-commitment-decarbonisation-reaffirmed-overwhelming-shareholder-support-climate-action#:~:text=Sasol%20committed%20to%20a%202050,Energy%20and%20Chemicals%20business%20units.",net_zero_tracker
-net_zero_tracker:3BNYRYQHD39K4LCKQF12:2030,3BNYRYQHD39K4LCKQF12,Absolute emission reduction,2019,2030,15,percent,https://www.marathonpetroleum.com/Sustainability/Lowering-Carbon-Intensity/,net_zero_tracker
-net_zero_tracker:3E70L4WYANTIWWIPHC81:2030,3E70L4WYANTIWWIPHC81,Absolute emission reduction,2020,2030,50,percent,https://tinyurl.com/2ktzzy7p,net_zero_tracker
-net_zero_tracker:3PPKBHUG1HD6BO7RNR87:2025,3PPKBHUG1HD6BO7RNR87,Absolute emission reduction,2020,2025,20,percent,https://www.textron.com/assets/CR/2019/ProductSustainabilityHighlights.html,net_zero_tracker
-net_zero_tracker:3SOUA6IRML7435B56G12:2022,3SOUA6IRML7435B56G12,Absolute emission reduction,2015,2022,15,percent,https://www.exeloncorp.com/newsroom/exelon-utilities-announces-goal-to-achieve-net-zero-emissions-by-2050,net_zero_tracker
-net_zero_tracker:4DR1VPDQMHD3N3QW8W95:2030,4DR1VPDQMHD3N3QW8W95,Relative emission reduction,2008,2030,40,percent,https://carnival-sustainability-2022.nyc3.digitaloceanspaces.com/assets/content/pdf/FY-2021-Sustainability-Report_Carnival-Corporation-and-plc.pdf,net_zero_tracker
-net_zero_tracker:4P4N3ORD02UGQT1T1W12:2030,4P4N3ORD02UGQT1T1W12,Absolute emission reduction,2019,2030,25,percent,https://www.marubeni.com/en/news/2021/release/00022.html,net_zero_tracker
-net_zero_tracker:52990016II9MJ2OSWA10:2035,52990016II9MJ2OSWA10,Absolute emission reduction,2019,2035,68,percent,https://www.cbre.com/-/media/project/cbre/dotcom/global/about/corporate-responsibility/cbre-2020-corporate-responsibility-report.pdf,net_zero_tracker
-net_zero_tracker:5299001GRRO0Z25YZT52:2030,5299001GRRO0Z25YZT52,Absolute emission reduction,2018,2030,50,percent,https://www.knorr-bremse.com/en/responsibility/,net_zero_tracker
-net_zero_tracker:5299001X9L42HXEBCZ51:2019,5299001X9L42HXEBCZ51,Absolute emission reduction,2015,2019,75,percent,https://www.ceconomy.de/en/sustainability/,net_zero_tracker
-net_zero_tracker:5299002D52YIP6DWMV49:2031,5299002D52YIP6DWMV49,Absolute emission reduction,2016,2031,40,percent,https://www.meiji.com/global/sustainability/caring_for_the_earth/climate_change/,net_zero_tracker
-net_zero_tracker:52990037G8JRM3TWGY86:2030,52990037G8JRM3TWGY86,Absolute emission reduction,2013,2030,30,percent,https://www.7andi.com/library/dbps_data/_template_/_res/en/csr/csrreport/2020/pdf/2020_all_01.pdf,net_zero_tracker
-net_zero_tracker:5299003D9N4JBS256X18:2030,5299003D9N4JBS256X18,Absolute emission reduction,2019,2030,46,percent,https://www.japanpost.jp/sustainability/environment/greenhouse_gas/#charge,net_zero_tracker
-net_zero_tracker:5299003FU7V4I45FU310:2030,5299003FU7V4I45FU310,Absolute emission reduction,2019,2030,50,percent,https://www.kddi.com/extlib/files/english/corporate/csr/csr_report/2021/pdf/report2021_en.pdf,net_zero_tracker
-net_zero_tracker:5299004EMJ3R4RVR5Y75:2030,5299004EMJ3R4RVR5Y75,Absolute emission reduction,2013,2030,50,percent,https://www.tepco.co.jp/en/hd/about/ir/library/integratedreport/index-e.html,net_zero_tracker
-net_zero_tracker:5299005F1HCVF4M4QN79:2030,5299005F1HCVF4M4QN79,Absolute emission reduction,2013,2030,72,percent,https://www.nri.com/en/sustainability/environment/policy,net_zero_tracker
-net_zero_tracker:5299006EQ03K3SSUYS12:2028,5299006EQ03K3SSUYS12,Absolute emission reduction,2018,2028,85,percent,https://www.merlinproperties.com/wp-content/uploads/2022/05/Pathway-to-Net-Zero-02_22-1.pdf,net_zero_tracker
-net_zero_tracker:5299006UDSEJCTTEJS30:2021,5299006UDSEJCTTEJS30,Absolute emission reduction,2011,2021,90,percent,https://www.verbund.com/-/media/verbund/ueber-verbund/verantwortung/umwelt/klimaschutz/verbund-climate-report-en.ashx?ori=1&la=en,net_zero_tracker
-net_zero_tracker:5299006ZTN6MO1N5BR16:2031,5299006ZTN6MO1N5BR16,Absolute emission reduction,2014,2031,17,percent,https://mmc.disclosure.site/en/themes/92,net_zero_tracker
-net_zero_tracker:5299009MXFL34SA71416:2030,5299009MXFL34SA71416,Absolute emission reduction,2019,2030,35,percent,https://www.irwebcasting.com/20210125/2/1045f40096/media/210125_aeon_en03.pdf,net_zero_tracker
-net_zero_tracker:529900A76GOP0PGNHT63:2030,529900A76GOP0PGNHT63,Absolute emission reduction,2013,2030,50,percent,https://www.chuden.co.jp/english/resource/esg/environment/zeroemissions/zeroemissions_01.pdf,net_zero_tracker
-net_zero_tracker:529900CXROT5S2HMMP26:2030,529900CXROT5S2HMMP26,Absolute emission reduction,2019,2030,50,percent,https://www.ms-ad-hd.com/en/ir/library/disclosure/main/015/teaserItems2/0/link/1115_en.pdf,net_zero_tracker
-net_zero_tracker:529900F3AIQECS8ZSV61:2025,529900F3AIQECS8ZSV61,Absolute emission reduction,2019,2025,20,percent,https://www.umicore.com/en/newsroom/news/umicore-unveils-bold-sustainability-ambitions-and-commits-to-achieving-carbon-neutrality-by-2035/,net_zero_tracker
-net_zero_tracker:529900F60CID3NCZM330:2025,529900F60CID3NCZM330,Absolute emission reduction,2018,2025,50,percent,https://socialresponsibility.carmax.com/,net_zero_tracker
-net_zero_tracker:529900FNDVTQJOVVPZ19:2023,529900FNDVTQJOVVPZ19,Absolute emission reduction,2020,2023,23,percent,https://www.thalesgroup.com/fr/group/journaliste/press-release/thales-comment-hautes-technologies-peuvent-reduire-court-terme,net_zero_tracker
-net_zero_tracker:529900G3SW56SHYNPR95:2023,529900G3SW56SHYNPR95,Absolute emission reduction,2021,2023,70,percent,https://deutsche-boerse.com/dbg-de/media/pressemitteilungen/Deutsche-B-rse-will-bis-2025-netto-klimaneutral-werden-2653534,net_zero_tracker
-net_zero_tracker:529900GB7KCA94ACC940:2030,529900GB7KCA94ACC940,Absolute emission reduction,2019,2030,50,percent,https://www.rwe.com/-/media/RWE/documents/09-responsibility-and-sustainability/cr-reports/EN/cr-report-2021.pdf,net_zero_tracker
-net_zero_tracker:529900GMNDOYQSAJAE76:2030,529900GMNDOYQSAJAE76,Absolute emission reduction,2013,2030,50,percent,https://www.sekisuihouse.co.jp/library/english/company/sustainable/2021/2021_all.pdf,net_zero_tracker
-net_zero_tracker:529900JH1GSC035SSP77:2030,529900JH1GSC035SSP77,Absolute emission reduction,2018,2030,30,percent,https://www.responsibilityreports.com/HostedData/ResponsibilityReportArchive/c/NYSE_CAJ_2021.pdf,net_zero_tracker
-net_zero_tracker:529900JI1GG6F7RKVI53:2030,529900JI1GG6F7RKVI53,Absolute emission reduction,2016,2030,25,percent,https://www.loreal-finance.com/eng/news-events/loreal-recognized-global-compact-lead-united-nations-and-steps-its-climate-action,net_zero_tracker
-net_zero_tracker:529900K9B0N5BT694847:2025,529900K9B0N5BT694847,Absolute emission reduction,2019,2025,25,percent,https://www.allianz.com/content/dam/onemarketing/azcom/Allianz_com/sustainability/documents/Allianz_Group_Sustainability_Report_2020-web.pdf,net_zero_tracker
-net_zero_tracker:529900LVC9GIIYUGE243:2030,529900LVC9GIIYUGE243,Absolute emission reduction,2018,2030,70,percent,https://ojiholdings.disclosure.site/en/themes/198/,net_zero_tracker
-net_zero_tracker:529900MUF4C20K50JS49:2025,529900MUF4C20K50JS49,Relative emission reduction,2019,2025,12,percent,https://www.munichre.com/content/dam/munichre/contentlounge/website-pieces/documents/munich_re_sustainability_report_2021.pdf/_jcr_content/renditions/original./munich_re_sustainability_report_2021.pdf,net_zero_tracker
-net_zero_tracker:529900NNUPAGGOMPXZ31:2025,529900NNUPAGGOMPXZ31,Absolute emission reduction,2018,2025,30,percent,https://www.volkswagenag.com/presence/nachhaltigkeit/documents/sustainability-report/2021/focus-topics/220310_VW_NB21_Decarbonization_EN.pdf,net_zero_tracker
-net_zero_tracker:529900O5RR7R39FRDM42:2030,529900O5RR7R39FRDM42,Absolute emission reduction,2017,2030,40,percent,https://hmgroup.com/sustainability/leading-the-change/goals-and-ambitions/,net_zero_tracker
-net_zero_tracker:529900OAREIS0MOPTW25:2030,529900OAREIS0MOPTW25,Absolute emission reduction,2020,2030,50,percent,https://www.merckgroup.com/en/sustainability/environment.html,net_zero_tracker
-net_zero_tracker:529900PM64WH8AF1E917:2030,529900PM64WH8AF1E917,Absolute emission reduction,2018,2030,25,percent,https://www.basf.com/global/en/media/news-releases/2021/03/p-21-166.html,net_zero_tracker
-net_zero_tracker:529900QVNRBND50TXP03:2025,529900QVNRBND50TXP03,Absolute emission reduction,2020,2025,50,percent,https://www.zurich.com/en/sustainability/sustainable-operations/net-zero,net_zero_tracker
-net_zero_tracker:529900R27DL06UVNT076:2030,529900R27DL06UVNT076,Absolute emission reduction,2018,2030,40,percent,https://www.daimler.com/sustainability/climate/ambition-2039-our-path-to-co2-neutrality.html,net_zero_tracker
-net_zero_tracker:529900S21EQ1BO4ESM68:2025,529900S21EQ1BO4ESM68,Absolute emission reduction,2015,2025,15,percent,https://sustainable-performance.totalenergies.com/en/our-challenges/environment-and-climate/climate,net_zero_tracker
-net_zero_tracker:529900S5R9YHJHYKKG94:2030,529900S5R9YHJHYKKG94,Relative emission reduction,2019,2030,58,percent,https://www.cez.cz/en/media/press-releases/cez-presents-clean-energy-of-tomorrow-its-production-portfolio-is-to-be-rebuilt-to-low-emissions-by-2030-144329,net_zero_tracker
-net_zero_tracker:529900S7NFNQ4FT6OP83:2030,529900S7NFNQ4FT6OP83,Absolute emission reduction,2015,2030,25,percent,https://www.dnp.co.jp/eng/sustainability/,net_zero_tracker
-net_zero_tracker:529900SM0FDLLYATXU36:2025,529900SM0FDLLYATXU36,Relative emission reduction,2017,2025,22,percent,https://www.baywa.com/en/responsibility/at-a-glance,net_zero_tracker
-net_zero_tracker:529900TF7XJKIOWMLQ79:2030,529900TF7XJKIOWMLQ79,Absolute emission reduction,2020,2030,62,percent,https://www.taisei.co.jp/english/csr/performance/iso26000/environment/,net_zero_tracker
-net_zero_tracker:529900UBKMFM0ST6H474:2030,529900UBKMFM0ST6H474,Absolute emission reduction,2013,2030,45,percent,https://www.fujifilm.com/files-holdings/en/sustainability/report/2021/sustainabilityreport2021_svpstories_en.pdf,net_zero_tracker
-net_zero_tracker:529900YRFFGH5AXU4S86:2025,529900YRFFGH5AXU4S86,Absolute emission reduction,2017,2025,80,percent,https://corporate.zalando.com/en/sustainability/reducing-our-carbon-footprint,net_zero_tracker
-net_zero_tracker:529900YT4O5S0LCXWD54:2030,529900YT4O5S0LCXWD54,Absolute emission reduction,2013,2030,25,percent,https://www.obayashi.co.jp/en/sustainability/environment/tcfd.html,net_zero_tracker
-net_zero_tracker:5493000CGCQY2OQU7669:2025,5493000CGCQY2OQU7669,Absolute emission reduction,2019,2025,25,percent,https://www.jabil.com/about-us/sustainability/our-operations-and-resources.html,net_zero_tracker
-net_zero_tracker:5493000KUC3Z24U77V93:2024,5493000KUC3Z24U77V93,Relative emission reduction,2019,2024,35,percent,https://reporting.swisslife.com/download/2021AR/en/FY21_SustainabilityReport_EN.pdf,net_zero_tracker
-net_zero_tracker:5493000QYMPFRTEY4K28:2031,5493000QYMPFRTEY4K28,Absolute emission reduction,2018,2031,55,percent,https://www.nec.com/en/global/csr/eco/risk.html,net_zero_tracker
-net_zero_tracker:5493001EZOOA66PTBR68:2025,5493001EZOOA66PTBR68,Absolute emission reduction,2019,2025,50,percent,https://atos.net/en/lp/integrated-report-2019/our-environment,net_zero_tracker
-net_zero_tracker:5493001Z3ZE83NGK8Y12:2025,5493001Z3ZE83NGK8Y12,Absolute emission reduction,2020,2025,25,percent,https://www.prudentialplc.com/en/news-and-insights/all-news/news-releases/2021/07-05-2021,net_zero_tracker
-net_zero_tracker:5493002CONDB4N2HKI23:2030,5493002CONDB4N2HKI23,Relative emission reduction,2019,2030,50,percent,https://www.parker.com/parkerimages/Parker.com/Countries-2011/United%20States/About%20Us/Documents/Parker%20Sustainability%20Report%202020.pdf,net_zero_tracker
-net_zero_tracker:5493002F0SC4JTBU5137:2024,5493002F0SC4JTBU5137,Absolute emission reduction,2019,2024,20,percent,https://www.stryker.com/content/m/c/2020-comprehensive-annual-report/environmental-sustainability/carbon-neutrality.html,net_zero_tracker
-net_zero_tracker:5493003S21INSLK2IP73:2030,5493003S21INSLK2IP73,Absolute emission reduction,2019,2030,15,percent,https://corporate.dow.com/documents/about/066-00338-01-2020-esg-report.pdf,net_zero_tracker
-net_zero_tracker:54930044KVSC06Z79I06:2030,54930044KVSC06Z79I06,Absolute emission reduction,2020,2030,50,percent,https://s21.q4cdn.com/507168367/files/doc_financials/2021/ar/Clorox-2021-Integrated-Annual-Report.pdf,net_zero_tracker
-net_zero_tracker:5493004JF0SDFLM8GD76:2030,5493004JF0SDFLM8GD76,Absolute emission reduction,2019,2030,30,percent,https://www.dupont.com/about/sustainability/acting-on-climate.html.html,net_zero_tracker
-net_zero_tracker:5493004LQ0B4T7QPQV17:2030,5493004LQ0B4T7QPQV17,Absolute emission reduction,2010,2030,50,percent,https://sustainability-cms-komatsu-s3.s3-ap-northeast-1.amazonaws.com/en/csr/pdf/KOMATSUCSR2022_en.pdf,net_zero_tracker
-net_zero_tracker:5493004SE33MRLPB1W98:2030,5493004SE33MRLPB1W98,Absolute emission reduction,2018,2030,60,percent,https://www.sojitz.com/en/csr/environment/carbon_neutrality/,net_zero_tracker
-net_zero_tracker:5493005SP87FL5TOS202:2035,5493005SP87FL5TOS202,Absolute emission reduction,2019,2035,60,percent,https://www.sumitomocorp.com/en/jp/sustainability/environmental-management/climate,net_zero_tracker
-net_zero_tracker:5493005X2GO78EFZ3E94:2025,5493005X2GO78EFZ3E94,Absolute emission reduction,2000,2025,25,percent,https://s201.q4cdn.com/858635754/files/doc_downloads/PayPal-2021-Global-Impact-Report.pdf,net_zero_tracker
-net_zero_tracker:5493006AIPA1V92YPP18:2030,5493006AIPA1V92YPP18,Absolute emission reduction,2013,2030,30,percent,https://www.sdk.co.jp/english/csr/environment/climate.html,net_zero_tracker
-net_zero_tracker:5493006IEVQEFQO40L83:2030,5493006IEVQEFQO40L83,Absolute emission reduction,2020,2030,50,percent,https://www.cognizant.com/us/en/documents/carbon-reduction-plan.pdf,net_zero_tracker
-net_zero_tracker:5493006IH2N2WMIBB742:2030,5493006IH2N2WMIBB742,Absolute emission reduction,2019,2030,45,percent,https://www.valeo.com/fr/valeo-sengage-a-atteindre-la-neutralite-carbone-en-2050-et-aura-deja-fait-45-du-chemin-dici-a-2030/,net_zero_tracker
-net_zero_tracker:5493006W3QUS5LMH6R84:2030,5493006W3QUS5LMH6R84,Absolute emission reduction,2013,2030,35,percent,https://global.toyota/pages/global_toyota/sustainability/report/sdb/sdb22_en.pdf,net_zero_tracker
-net_zero_tracker:54930070J9H97ZO93T57:2050,54930070J9H97ZO93T57,Absolute emission reduction,2005,2050,50,percent,https://www.jetblue.com/sustainability/climate-leadership,net_zero_tracker
-net_zero_tracker:54930070NSV60J38I987:2035,54930070NSV60J38I987,Absolute emission reduction,2018,2035,72,percent,https://www.gmsustainability.com/_pdf/resources-and-downloads/GM_2020_SR.pdf,net_zero_tracker
-net_zero_tracker:549300772D1G8JPIUR96:2025,549300772D1G8JPIUR96,Absolute emission reduction,2021,2025,25,percent,https://www.aegon.com/investors/press-releases/2021/aegon-commits-to-group-wide-net-zero-emissions-objective-by-2050/,net_zero_tracker
-net_zero_tracker:5493007HIVTX6SY6XD66:2025,5493007HIVTX6SY6XD66,Absolute emission reduction,2016,2025,100,percent,https://www.novartis.com/our-company/corporate-responsibility/environmental-sustainability/climate,net_zero_tracker
-net_zero_tracker:5493007JDSMX8Z5Z1902:2022,5493007JDSMX8Z5Z1902,Absolute emission reduction,2020,2022,8,percent,https://www.campbellsoupcompany.com/newsroom/news/reducing-greenhouse-gas-emissions-in-our-operations/,net_zero_tracker
-net_zero_tracker:5493008C12PZMWP3WY03:2025,5493008C12PZMWP3WY03,Relative emission reduction,2018,2025,12,percent,https://www.kcsouthern.com/corporate-responsibility/our-commitment/KCS-2019-Sustainability-Report.pdf,net_zero_tracker
-net_zero_tracker:5493008FFSI8SQ74AT93:2030,5493008FFSI8SQ74AT93,Absolute emission reduction,2013,2030,26,percent,https://global.kawasaki.com/en/corp/sustainability/environment/20_houkokusyo.pdf,net_zero_tracker
-net_zero_tracker:5493008H3828EMEXB082:2025,5493008H3828EMEXB082,Absolute emission reduction,2017,2025,25,percent,https://www.ab-inbev.com/assets/pdfs/Net%20Zero%20Executive%20Summary_FINAL%2012pm.pdf,net_zero_tracker
-net_zero_tracker:5493008IRKIY0G3TE305:2030,5493008IRKIY0G3TE305,Absolute emission reduction,2019,2030,33,percent,https://www.anahd.co.jp/group/en/pr/202104/20210426.html,net_zero_tracker
-net_zero_tracker:5493008IUOJ5VWTRC333:2030,5493008IUOJ5VWTRC333,Relative emission reduction,2015,2030,10,percent,https://www.interpublic.com/wp-content/uploads/2021/08/CDP-Climate-Change-Questionnaire-2021_Interpublic-Group.pdf,net_zero_tracker
-net_zero_tracker:5493008T4YG3AQUI7P67:2025,5493008T4YG3AQUI7P67,Absolute emission reduction,2020,2025,30,percent,https://www.cellnextelecom.com/content/uploads/2021/07/Cellnex-Telecom_-Environmental-and-Climate-Change-Report.pdf,net_zero_tracker
-net_zero_tracker:5493009ML300G373MZ12:2030,5493009ML300G373MZ12,Absolute emission reduction,2005,2030,50,percent,https://www.alliantenergy.com/AboutAlliantEnergy/ResponsibilityReport/CleanEnergyVisionGoals,net_zero_tracker
-net_zero_tracker:549300B6HWYEE57O8J84:2020,549300B6HWYEE57O8J84,Absolute emission reduction,2015,2020,35,percent,https://www.skf.com/uk/organisation/sustainability/decarbonizing,net_zero_tracker
-net_zero_tracker:549300B8P6MUJ1YWTS08:2030,549300B8P6MUJ1YWTS08,Absolute emission reduction,2019,2030,50,percent,https://newclimate.org/wp-content/uploads/2022/02/CorporateClimateResponsibilityMonitor2022.pdf,net_zero_tracker
-net_zero_tracker:549300BMOJ05INE4YK86:2026,549300BMOJ05INE4YK86,Absolute emission reduction,2009,2026,35,percent,https://esg.vno.com/,net_zero_tracker
-net_zero_tracker:549300BX44RGX6ANDV88:2025,549300BX44RGX6ANDV88,Absolute emission reduction,2016,2025,55,percent,https://www.hpe.com/us/en/living-progress/carbon-footprint.html,net_zero_tracker
-net_zero_tracker:549300BX44RGX6ANDV88:2030,549300BX44RGX6ANDV88,Absolute emission reduction,2019,2030,50,percent,https://press.hp.com/us/en/press-releases/2021/hp-inc-announces-ambitious-climate-action-goals.html,net_zero_tracker
-net_zero_tracker:549300CEE2ENIUJNXB84:2030,549300CEE2ENIUJNXB84,Absolute emission reduction,2019,2030,50,percent,https://www.toyota-tsusho.com/english/ir/library/integrated-report/pdf/ar2021e_all.pdf,net_zero_tracker
-net_zero_tracker:549300CSY4INHEHQQT13:2020,549300CSY4INHEHQQT13,Absolute emission reduction,2014,2020,18,percent,https://www.kubota.com/sustainability/environment/ghg/index.html,net_zero_tracker
-net_zero_tracker:549300CZ8QS1GE53O776:2030,549300CZ8QS1GE53O776,Absolute emission reduction,2019,2030,50,percent,https://www.jacobs.com/sites/default/files/2022-04/Jacobs%20Climate%20Action%20Plan.pdf,net_zero_tracker
-net_zero_tracker:549300D8GOWWH0SJB189:2025,549300D8GOWWH0SJB189,Absolute emission reduction,2005,2025,50,percent,https://www.nisource.com/docs/librariesprovider2/sustainability-archives/2021/2021-cdp-climate-change-response.pdf?sfvrsn=4,net_zero_tracker
-net_zero_tracker:549300DFVPOB67JL3A42:2030,549300DFVPOB67JL3A42,Absolute emission reduction,2017,2030,25,percent,https://www.imperialbrandsplc.com/content/dam/imperialbrands/corporate2022/documents/investors/reports/annual-report-2021.pdf.downloadasset.pdf,net_zero_tracker
-net_zero_tracker:549300DHPOF90OYYD780:2030,549300DHPOF90OYYD780,Absolute emission reduction,2011,2030,50,percent,https://www.bridgestone.com/responsibilities/library/pdf/sr2020.pdf,net_zero_tracker
-net_zero_tracker:549300DRQQI75D2JP341:2030,549300DRQQI75D2JP341,Absolute emission reduction,2019,2030,35,percent,https://filecache.investorroom.com/mr5ir_truist/611/Truist%202021%20ESG%20and%20CSR%20Report%20%28ADA%29.pdf,net_zero_tracker
-net_zero_tracker:549300DSFX2IE88NSX47:2030,549300DSFX2IE88NSX47,Relative emission reduction,2015,2030,50,percent,https://www.borgwarner.com/company/sustainability#environmental-stewardship,net_zero_tracker
-net_zero_tracker:549300DV9GIB88LZ5P30:2025,549300DV9GIB88LZ5P30,Absolute emission reduction,2018,2025,10,percent,https://www.mondelezinternational.com/-/media/Mondelez/Snacking-Made-Right/SMR-Report/2021/2021-MDLZ-Snacking-Made-Right-ESG-Report.pdf,net_zero_tracker
-net_zero_tracker:549300E9PC51EN656011:2030,549300E9PC51EN656011,Absolute emission reduction,2019,2030,55,percent,https://integrated-report.sanofi.com/strategy/building-sustainability-for-a-healthy-planet/,net_zero_tracker
-net_zero_tracker:549300EEJH4FEPDBBR25:2025,549300EEJH4FEPDBBR25,Absolute emission reduction,2015,2025,90,percent,https://www.telefonica.com/documents/364672/413993/telefonica-cdp-climate-change-questionnaire-2020.pdf/4fa2d4f0-3bbd-d391-9931-8671bdb18f65,net_zero_tracker
-net_zero_tracker:549300EFP3TNG7JGVE49:2030,549300EFP3TNG7JGVE49,Absolute emission reduction,2017,2030,25,percent,https://www.coca-colahellenic.com/en/media/news/sustainability_news/2021/coca-cola-hbc-commits-to-net-zero-emissions-by-2040,net_zero_tracker
-net_zero_tracker:549300EI6OKH5K5Q2G38:2030,549300EI6OKH5K5Q2G38,Absolute emission reduction,2019,2030,47,percent,https://www.mtn.com/mtn-commits-to-net-zero-emissions-by-2040-to-contribute-to-a-sustainable-future/,net_zero_tracker
-net_zero_tracker:549300EJG376EN5NQE29:2030,549300EJG376EN5NQE29,Absolute emission reduction,2019,2030,47,percent,https://cvshealth.com/sites/default/files/2020-csr-report.pdf,net_zero_tracker
-net_zero_tracker:549300EJG9IEYQL5XT21:2025,549300EJG9IEYQL5XT21,Absolute emission reduction,2018,2025,70,percent,https://www.tiffany.co.uk/sustainability/the-planet/efficient-energy/,net_zero_tracker
-net_zero_tracker:549300EVUN2BTLJ3GT74:2030,549300EVUN2BTLJ3GT74,Absolute emission reduction,2019,2030,50,percent,https://www.equinix.co.uk/newsroom/press-releases/2021/06/equinix-sets-2030-global-climate-neutral-target,net_zero_tracker
-net_zero_tracker:549300FA4CTCW903Y781:2025,549300FA4CTCW903Y781,Absolute emission reduction,2011,2025,35,percent,https://www.caesars.com/corporate/corporate-social-responsibility/planet/climate,net_zero_tracker
-net_zero_tracker:549300FC3G3YU2FBZD92:2030,549300FC3G3YU2FBZD92,Absolute emission reduction,2007,2030,50,percent,https://www.southerncompany.com/sustainability/net-zero-and-environmental-priorities/net-zero-transition.html,net_zero_tracker
-net_zero_tracker:549300FONLMVK7YYYH41:2030,549300FONLMVK7YYYH41,Absolute emission reduction,2019,2030,30,percent,https://www.suntory.com/csr/activity/environment/management/vision/,net_zero_tracker
-net_zero_tracker:549300GCEDD8YCF5WU84:2030,549300GCEDD8YCF5WU84,Absolute emission reduction,2019,2030,50,percent,https://www.moodys.com/sites/products/ProductAttachments/Sustainability/moodys_decarbonization_plan.pdf,net_zero_tracker
-net_zero_tracker:549300GHBMY8T5GXDE41:2030,549300GHBMY8T5GXDE41,Absolute emission reduction,2021,2030,60,percent,https://www.unitedhealthgroup.com/content/dam/UHG/PDF/About/UNH-enivronmental-impact-statement.pdf,net_zero_tracker
-net_zero_tracker:549300GLKVIO8YRCYN02:2030,549300GLKVIO8YRCYN02,Absolute emission reduction,2019,2030,55,percent,https://www.keysight.com/us/en/assets/7018-06607/brochures/5992-3927.pdf,net_zero_tracker
-net_zero_tracker:549300H5LSF8DP3RIJ34:2025,549300H5LSF8DP3RIJ34,Relative emission reduction,2014,2025,20,percent,https://www.tel.com/csr/environment/,net_zero_tracker
-net_zero_tracker:549300HGGKEL4FYTTQ83:2025,549300HGGKEL4FYTTQ83,Absolute emission reduction,2018,2025,20,percent,http://sustainability.steeldynamics.com/valuing-our-environment/,net_zero_tracker
-net_zero_tracker:549300I4GMO6D34U1T02:2025,549300I4GMO6D34U1T02,Absolute emission reduction,2019,2025,25,percent,https://www.lamresearch.com/esg-report/downloads/Lam-Research-2021-ESG-Report.pdf,net_zero_tracker
-net_zero_tracker:549300I7ROF15MAEVP56:2030,549300I7ROF15MAEVP56,Absolute emission reduction,1990,2030,40,percent,https://www.edison.com/content/dam/eix/documents/sustainability/eix-2021-sustainability-report.pdf,net_zero_tracker
-net_zero_tracker:549300IGLYTZUK3PVP70:2025,549300IGLYTZUK3PVP70,Absolute emission reduction,2005,2025,60,percent,https://www.wecenergygroup.com/home/generation-reshaping-plan.htm,net_zero_tracker
-net_zero_tracker:549300IRDTHJQ1PVET45:2030,549300IRDTHJQ1PVET45,Relative emission reduction,2018,2030,15,percent,https://www.responsibilityreports.com/HostedData/ResponsibilityReports/PDF/NYSE_FCX_2020.pdf,net_zero_tracker
-net_zero_tracker:549300ITS31QK8VRBQ14:2030,549300ITS31QK8VRBQ14,Absolute emission reduction,2016,2030,60,percent,https://newscorp.com/news-corp-sustainability/,net_zero_tracker
-net_zero_tracker:549300IULC8F8IGXKI15:2023,549300IULC8F8IGXKI15,Absolute emission reduction,2020,2023,50,percent,https://www.lundin-energy.com/sustainability/climate-change/decarbonisation-strategy/,net_zero_tracker
-net_zero_tracker:549300IX8SD6XXD71I78:2023,549300IX8SD6XXD71I78,Absolute emission reduction,2005,2023,32,percent,https://dtecleanenergy.com/,net_zero_tracker
-net_zero_tracker:549300J0DYC0N31V7G13:2021,549300J0DYC0N31V7G13,Relative emission reduction,2020,2021,48,percent,https://www.workday.com/en-gb/company/corporate-responsibility/sustainability.html,net_zero_tracker
-net_zero_tracker:549300J4U55H3WP1XT59:2024,549300J4U55H3WP1XT59,Absolute emission reduction,2019,2024,20,percent,https://www.bayer.com/en/sustainability/climate-protection,net_zero_tracker
-net_zero_tracker:549300JE8XHZZ7OHN517:2030,549300JE8XHZZ7OHN517,Absolute emission reduction,2019,2030,46,percent,https://www.yum.com/wps/portal/yumbrands/Yumbrands/citizenship-and-sustainability/planet,net_zero_tracker
-net_zero_tracker:549300JF6LPRTRJ0FH50:2025,549300JF6LPRTRJ0FH50,Absolute emission reduction,2014,2025,50,percent,https://corporate.kohls.com/content/dam/kohlscorp/corporate-responsibility/landing-page/Kohls-ESG%20Report.pdf,net_zero_tracker
-net_zero_tracker:549300JQQA6MQ4OJP259:2030,549300JQQA6MQ4OJP259,Absolute emission reduction,2020,2030,42,percent,https://mccormick.widen.net/s/x5bmvpfgc7/2021_plp_report,net_zero_tracker
-net_zero_tracker:549300JSX0Z4CW0V5023:2030,549300JSX0Z4CW0V5023,Absolute emission reduction,2017,2030,30,percent,https://www.adidas-group.com/media/filer_public/a8/5c/a85c9b8e-865b-4237-8def-8574be243577/annual_report_gb-2019_en.pdf,net_zero_tracker
-net_zero_tracker:549300KI75VYLLMSK856:2035,549300KI75VYLLMSK856,Absolute emission reduction,2018,2035,50,percent,https://www.sse.com/media/q0ilyek3/net-zero-transition-report-final.pdf,net_zero_tracker
-net_zero_tracker:549300KMHPUAQI8VEH90:2030,549300KMHPUAQI8VEH90,Absolute emission reduction,2017,2030,40,percent,https://www.jpower.co.jp/english/ir/ir51000.html,net_zero_tracker
-net_zero_tracker:549300KP43CPCUJOOG15:2030,549300KP43CPCUJOOG15,Absolute emission reduction,2010,2030,60,percent,https://www.vistracorp.com/wp-content/uploads/2020/11/VST-2020-Climate-Report.pdf,net_zero_tracker
-net_zero_tracker:549300LBHTST91VKHO68:2030,549300LBHTST91VKHO68,Absolute emission reduction,2019,2030,50,percent,https://www.toshiba.co.jp/env/en/vision/vision2050_0.htm,net_zero_tracker
-net_zero_tracker:549300LMMRSZZCZ8CL11:2030,549300LMMRSZZCZ8CL11,Absolute emission reduction,2018,2030,26,percent,https://www.responsibilityreports.com/HostedData/ResponsibilityReports/PDF/NYSE_UNP_2021.pdf,net_zero_tracker
-net_zero_tracker:549300LRIF3NWCU26A80:2030,549300LRIF3NWCU26A80,Absolute emission reduction,2020,2030,50,percent,https://www.blackrock.com/corporate/investor-relations/blackrock-client-letter,net_zero_tracker
-net_zero_tracker:549300LSGBXPYHXGDT93:2025,549300LSGBXPYHXGDT93,Absolute emission reduction,2019,2025,85,percent,https://www.wpp.com/-/media/project/wpp/files/sustainability/reports/2021/wpp_sr_2021_interactive-------.pdf?la=en,net_zero_tracker
-net_zero_tracker:549300LTH67W4GWMRF57:2030,549300LTH67W4GWMRF57,Absolute emission reduction,2019,2030,30,percent,https://www.cocacolaep.com/assets/2021-CCEP-Integrated-Report-and-Form-20-F_v2-v2.pdf,net_zero_tracker
-net_zero_tracker:549300M3VH1A3ER1TB49:2030,549300M3VH1A3ER1TB49,Absolute emission reduction,2016,2030,35,percent,https://www.essity.com/sustainability/our-journey-to-net-zero/climate-targets/,net_zero_tracker
-net_zero_tracker:549300MMVL80RTBP3O28:2030,549300MMVL80RTBP3O28,Absolute emission reduction,2018,2030,30,percent,https://www.solvay.com/en/sustainability/climate,net_zero_tracker
-net_zero_tracker:549300MR6PG2DWZUIL39:2025,549300MR6PG2DWZUIL39,Absolute emission reduction,2019,2025,15,percent,https://www.aramark.com/content/dam/aramark/en/environmental-social-governance/reporting/Aramark-2021-Impact-Report.pdf,net_zero_tracker
-net_zero_tracker:549300N244BVAEE6HH86:2030,549300N244BVAEE6HH86,Absolute emission reduction,2016,2030,30,percent,https://www.subaru.co.jp/en/csr/subaru_csr/sixpriority/environment.html,net_zero_tracker
-net_zero_tracker:549300NYKK9MWM7GGW15:2030,549300NYKK9MWM7GGW15,Absolute emission reduction,2014,2030,90,percent,https://www.ing.com/Sustainability/The-world-around-us-1/Reporting.htm,net_zero_tracker
-net_zero_tracker:549300OF70FSEUQBT254:2025,549300OF70FSEUQBT254,Relative emission reduction,2008,2025,32,percent,https://www.bxp.com/commitment,net_zero_tracker
-net_zero_tracker:549300OJ9VZHZRO6I137:2025,549300OJ9VZHZRO6I137,Absolute emission reduction,2015,2025,20,percent,https://s23.q4cdn.com/539497486/files/doc_downloads/2022/04/Tractor-Supply-Sustainability-Report-FY2021.pdf,net_zero_tracker
-net_zero_tracker:549300P0R46FF6DUA630:2030,549300P0R46FF6DUA630,Absolute emission reduction,2017,2030,0,percent,https://sustainability.idemitsu.com/en/themes/311,net_zero_tracker
-net_zero_tracker:549300P7ZYCQJ36CCS16:2020,549300P7ZYCQJ36CCS16,Absolute emission reduction,2000,2020,30,percent,https://global.honda/content/dam/site/global/about/cq_img/sustainability/report/pdf/2021/Honda-SR-2021-en-all.pdf,net_zero_tracker
-net_zero_tracker:549300PGTHDQY6PSUI61:2030,549300PGTHDQY6PSUI61,Absolute emission reduction,2005,2030,70,percent,https://investors.evergy.com/news-releases/news-release-details/evergy-sets-goal-net-zero-carbon-emissions-2045-interim-carbon,net_zero_tracker
-net_zero_tracker:549300PW7VPFCYKLIV37:2030,549300PW7VPFCYKLIV37,Absolute emission reduction,2015,2030,70,percent,https://esg.averydennison.com/en/home/environmental-footprint/ghg-emissions-and-energy-use.html,net_zero_tracker
-net_zero_tracker:549300QD81EPLH4NUQ92:2025,549300QD81EPLH4NUQ92,Absolute emission reduction,2015,2025,75,percent,https://www.results.philips.com/publications/ar20,net_zero_tracker
-net_zero_tracker:549300QQXOOYEF89IC56:2030,549300QQXOOYEF89IC56,Relative emission reduction,2020,2030,50,percent,https://www.responsibilityreports.com/HostedData/ResponsibilityReports/PDF/NASDAQ_WDC_2021.pdf,net_zero_tracker
-net_zero_tracker:549300R22LSX6OHWEN64:2024,549300R22LSX6OHWEN64,Relative emission reduction,2019,2024,50,percent,https://www.diamondbackenergy.com/news-releases/news-release-details/diamondback-energy-inc-announces-fourth-quarter-and-full-year-1,net_zero_tracker
-net_zero_tracker:549300RPTUOIXG4LIH86:2020,549300RPTUOIXG4LIH86,Relative emission reduction,2011,2020,20,percent,https://www.walgreensbootsalliance.com/sites/www/files/2021-01/WBA_CDP_Climate_Change_Questionnaire_2020_26%20Aug.pdf,net_zero_tracker
-net_zero_tracker:549300S9XF92D1X8ME43:2030,549300S9XF92D1X8ME43,Absolute emission reduction,2016,2030,30,percent,https://www.angloamerican.com/~/media/Files/A/Anglo-American-Group/PLC/investors/annual-reporting/2022/aa-sustainability-report-full-2021.pdf,net_zero_tracker
-net_zero_tracker:549300SQYI82RVWFN715:2030,549300SQYI82RVWFN715,Absolute emission reduction,2011,2030,60,percent,https://responsibility.metroag.de/focus-areas/climate-action,net_zero_tracker
-net_zero_tracker:549300SVYJS666PQJH88:2030,549300SVYJS666PQJH88,Absolute emission reduction,2019,2030,30,percent,https://www.firstenergycorp.com/newsroom/news_articles/firstenergy-pledges-to-achieve-carbon-neutrality-by-2050.html,net_zero_tracker
-net_zero_tracker:549300T6IPOCDWLKC615:2030,549300T6IPOCDWLKC615,Absolute emission reduction,2010,2030,50,percent,https://sustainability.hitachi.com/wp-content/uploads/2021/10/en_sustainability2021_full.pdf,net_zero_tracker
-net_zero_tracker:549300TRXM9Y6561AX39:2030,549300TRXM9Y6561AX39,Absolute emission reduction,2017,2030,18,percent,https://www.mitsubishielectric.com/en/sustainability/reports/pdf/2021/Sustainability_report_2021_all.pdf,net_zero_tracker
-net_zero_tracker:549300TTCXZOGZM2EY83:2030,549300TTCXZOGZM2EY83,Absolute emission reduction,2018,2030,90,percent,https://www.inditex.com/our-commitment-to-the-environment/climate-change-and-energy,net_zero_tracker
-net_zero_tracker:549300U41AUUVOAAOB37:2025,549300U41AUUVOAAOB37,Absolute emission reduction,2015,2025,38,percent,https://www.roche.com/sustainability/environment/our_she_goals_and_performance.htm,net_zero_tracker
-net_zero_tracker:549300UDG16DOYUPR330:2030,549300UDG16DOYUPR330,Absolute emission reduction,2018,2030,30,percent,https://ucpcdn.thyssenkrupp.com/_binary/UCPthyssenkruppAG/en/investors/presentations-and-events/capital-market-days/berichterstattung-und-publikationen-kopie/link-thyssenkrupp-GB-2019-2020-EN-Web.pdf,net_zero_tracker
-net_zero_tracker:549300UINV5RINHGMG07:2030,549300UINV5RINHGMG07,Absolute emission reduction,2015,2030,70,percent,https://group.skanska.com/4938df/siteassets/investors/reports-publications/annual-reports/2021/annual-and-sustainability-report-2021.pdf,net_zero_tracker
-net_zero_tracker:549300UPNBTXA1SYTQ33:2030,549300UPNBTXA1SYTQ33,Absolute emission reduction,2019,2030,50,percent,https://assets.website-files.com/6019e43dcfad3c059841794a/60a6d3d36ca419aff05b0371_2020%20Sustainability%20Report%20052021-min.pdf,net_zero_tracker
-net_zero_tracker:549300V62YJ9HTLRI486:2040,549300V62YJ9HTLRI486,Relative emission reduction,2019,2040,50,percent,https://reports.omv.com/en/sustainability-report/2021/servicepages/downloads/files/entire-omv-sr21.pdf,net_zero_tracker
-net_zero_tracker:549300VIWYMSIGT1U456:2030,549300VIWYMSIGT1U456,Absolute emission reduction,2019,2030,50,percent,https://www.cigna.com/about-us/corporate-responsibility/report/environment/sustainability-performance-plan,net_zero_tracker
-net_zero_tracker:549300VSP3RIX7FGDZ51:2030,549300VSP3RIX7FGDZ51,Absolute emission reduction,2018,2030,32,percent,https://s24.q4cdn.com/382246808/files/doc_downloads/sustainability/2021-report/newmont-2021-sustainability-report.pdf,net_zero_tracker
-net_zero_tracker:549300VZCL1HTH4O4Y49:2025,549300VZCL1HTH4O4Y49,Absolute emission reduction,2010,2025,65,percent,https://www.henkel.com/spotlight/features/climate-action,net_zero_tracker
-net_zero_tracker:549300WSX3VBUFFJOO66:2025,549300WSX3VBUFFJOO66,Absolute emission reduction,2015,2025,46,percent,https://www.relx.com/media/press-releases/year-2021/net-zero,net_zero_tracker
-net_zero_tracker:549300WTZWR07K8MNV44:2030,549300WTZWR07K8MNV44,Absolute emission reduction,2019,2030,46,percent,https://www.gilead.com/-/media/files/pdfs/yir-2021-pdfs/2021-gilead-yir_desktop.pdf?la=en&hash=5435F68EB8113745A8756DB75947E7B4,net_zero_tracker
-net_zero_tracker:549300WZN9I2QKLS0O94:2030,549300WZN9I2QKLS0O94,Relative emission reduction,2020,2030,65,percent,https://www.corteva.com/content/dam/dpagco/corteva/global/corporate/files/sustainability/DOC-CORTEVA_2020_SUSTAINABILITY_REPORT_v2-Global.pdf,net_zero_tracker
-net_zero_tracker:549300X2937PB0CJ7I56:2028,549300X2937PB0CJ7I56,Absolute emission reduction,2021,2028,30,percent,https://www.corning.com/media/worldwide/global/documents/2021_Sustainability_Report_Corning_Incorporated.pdf,net_zero_tracker
-net_zero_tracker:549300X3UK4GG3FNMO06:2030,549300X3UK4GG3FNMO06,Absolute emission reduction,2017,2030,50,percent,https://www.edf.fr/en/the-edf-group/taking-action-as-a-responsible-company/reports-and-indicators/2021-impact-report,net_zero_tracker
-net_zero_tracker:549300XMP3KDCKJXIU47:2030,549300XMP3KDCKJXIU47,Absolute emission reduction,2019,2030,50,percent,https://www.marshmclennan.com/content/dam/mmc-web/v3/esg/Marsh-McLennan-2021-ESG-Report-FINAL.pdf,net_zero_tracker
-net_zero_tracker:549300XTO5VR8SKV1V74:2025,549300XTO5VR8SKV1V74,Absolute emission reduction,2011,2025,63,percent,https://www.valero.com/sites/default/files/valero-documents/2020%20SRR_Web%20Version_Spreads%207-26.pdf,net_zero_tracker
-net_zero_tracker:549300YECS8HKCIMMB67:2030,549300YECS8HKCIMMB67,Absolute emission reduction,2020,2030,50,percent,https://www.assaabloy.com/group/en/news-media/press-releases/id.CFA9811B900E9B83,net_zero_tracker
-net_zero_tracker:549300YX8JIID70NFS41:2032,549300YX8JIID70NFS41,Absolute emission reduction,2021,2032,42,percent,https://sustainability.wm.com/downloads/WM_2022_SR.pdf,net_zero_tracker
-net_zero_tracker:549300Z40J86GGSTL398:2030,549300Z40J86GGSTL398,Absolute emission reduction,2015,2030,63,percent,https://about.att.com/csr/home/reporting/issue-brief/climate-change.html,net_zero_tracker
-net_zero_tracker:549300ZFEEJ2IP5VME73:2030,549300ZFEEJ2IP5VME73,Absolute emission reduction,2019,2030,27,percent,https://www.statestreet.com/content/dam/statestreet/documents/values/state-street-esg-report-04-2021.pdf,net_zero_tracker
-net_zero_tracker:549300ZHW0TR2QZ0NY83:2030,549300ZHW0TR2QZ0NY83,Absolute emission reduction,2016,2030,32,percent,https://sustainability.omron.com/en/environ/climate_change/response/#Anchor-pageLink02,net_zero_tracker
-net_zero_tracker:549300ZLMVP4X0OGR454:2025,549300ZLMVP4X0OGR454,Absolute emission reduction,2016,2025,40,percent,https://www.takeda.com/49f45f/siteassets/system/corporate-responsibility/reporting-on-sustainability/tcfd.pdf,net_zero_tracker
-net_zero_tracker:5E2UPK5SW04M13XY7I38:2025,5E2UPK5SW04M13XY7I38,Absolute emission reduction,2014,2025,50,percent,https://www.nrg.com/assets/documents/sustainability/2021-sustainability-report.pdf,net_zero_tracker
-net_zero_tracker:6EY4K7ZMF9UX1CU6KC79:2025,6EY4K7ZMF9UX1CU6KC79,Absolute emission reduction,2015,2025,25,percent,https://www.xilinx.com/content/dam/xilinx/publications/about/xilinx-cdp-climate-change-2021.pdf,net_zero_tracker
-net_zero_tracker:6SYKCME112RT8TQUO411:2034,6SYKCME112RT8TQUO411,Absolute emission reduction,2018,2034,68,percent,https://www.jll.co.uk/content/dam/jll-com/documents/pdf/other/jll-global-sustainability-full-report-2020.pdf,net_zero_tracker
-net_zero_tracker:724500K5PTPSST86UQ23:2030,724500K5PTPSST86UQ23,Absolute emission reduction,2018,2030,90,percent,https://www.theheinekencompany.com/sites/theheinekencompany/files/Downloads/PDF/sustainability%20and%20responsibility/heineken-on-the-path-to-net-zero-2021.pdf?_ga=2.145104438.301010175.1647426557-347249191.1647426557,net_zero_tracker
-net_zero_tracker:724500OHYNDT9OY6Q215:2025,724500OHYNDT9OY6Q215,Absolute emission reduction,2019,2025,25,percent,https://www.nn-group.com/nn-group/file?uuid=fe0ed772-850a-4697-95e5-06a1fe376e0f&owner=84c25534-c28a-4a64-9c78-5cc1388e4766&contentid=11805,net_zero_tracker
-net_zero_tracker:724500SNT1MK246AHP04:2030,724500SNT1MK246AHP04,Absolute emission reduction,2016,2030,50,percent,https://www.dsm.com/corporate/sustainability/climate-energy/improving-our-carbon-footprint.html,net_zero_tracker
-net_zero_tracker:724500XYIJUGXAA5QD70:2030,724500XYIJUGXAA5QD70,Absolute emission reduction,2020,2030,42,percent,https://www.akzonobel.com/en/about-us/position-statements/climate-change,net_zero_tracker
-net_zero_tracker:7890005U0H950VH19H45:2030,7890005U0H950VH19H45,Absolute emission reduction,2013,2030,30,percent,https://www.kobelco.co.jp/english/about_kobelco/outline/integrated-reports/files/integrated-reports2021_e.pdf,net_zero_tracker
-net_zero_tracker:7CUNS533WID6K7DGFI87:2024,7CUNS533WID6K7DGFI87,Absolute emission reduction,2021,2024,19,percent,https://www.caixabank.com/deployedfiles/caixabank_com/Estaticos/PDFs/Accionistasinversores/Informacion_economico_financiera/IGC_30062022_ING.pdf,net_zero_tracker
-net_zero_tracker:815600354DEDBD0BA991:2025,815600354DEDBD0BA991,Absolute emission reduction,2020,2025,30,percent,https://www.annualreports.com/HostedData/AnnualReports/PDF/poste-italiane_2021.pdf,net_zero_tracker
-net_zero_tracker:82DYEISM090VG8LTLS26:2030,82DYEISM090VG8LTLS26,Absolute emission reduction,2018,2030,50,percent,https://en-uk.ecolab.com/corporate-responsibility/2030-impact-goals,net_zero_tracker
-net_zero_tracker:851WYGNLUQLFZBSYGB56:2025,851WYGNLUQLFZBSYGB56,Absolute emission reduction,2018,2025,30,percent,https://www.commerzbank.de/en/nachhaltigkeit/gesellschaft/klimastrategie/standardseitenvorlage_3.html,net_zero_tracker
-net_zero_tracker:894500ZRIX9K13RHXR17:2025,894500ZRIX9K13RHXR17,Absolute emission reduction,2019,2025,18,percent,https://www.te.com/usa-en/about-te/corporate-responsibility.html,net_zero_tracker
-net_zero_tracker:8I5DZWZKVSZI1NUHU748:2030,8I5DZWZKVSZI1NUHU748,Absolute emission reduction,2017,2030,40,percent,https://www.jpmorganchase.com/content/dam/jpmc/jpmorgan-chase-and-co/documents/jpmc-esg-report-2020.pdf,net_zero_tracker
-net_zero_tracker:8R95QZMKZLJX5Q2XR704:2030,8R95QZMKZLJX5Q2XR704,Absolute emission reduction,1990,2030,80,percent,https://www.nationalgrid.com/stories/journey-to-net-zero/national-grids-net-zero-commitment,net_zero_tracker
-net_zero_tracker:8WDDFXB5T1Z6J0XC1L66:2030,8WDDFXB5T1Z6J0XC1L66,Absolute emission reduction,2017,2030,32,percent,https://corporate.target.com/corporate-responsibility/planet/climate,net_zero_tracker
-net_zero_tracker:95980020140005007414:2030,95980020140005007414,Absolute emission reduction,2015,2030,75,percent,https://www.inmocolonial.com/sites/default/files/69792_colonial_2020_web_eng.pdf,net_zero_tracker
-net_zero_tracker:9598004A3FTY3TEHHN09:2030,9598004A3FTY3TEHHN09,Absolute emission reduction,2015,2030,100,percent,https://corporate.amadeus.com/documents/en/resources/corporate-information/corporate-documents/global-reports/2020/amadeus-global-report-2020.pdf,net_zero_tracker
-net_zero_tracker:959800HSSNXWRKBK4N60:2030,959800HSSNXWRKBK4N60,Absolute emission reduction,2021,2030,55,percent,https://www.grifols.com/documents/3625622/3683813/sustainability-report-2021-en.pdf/9588cf72-d301-5beb-da48-ff3469851746?t=1647279808393,net_zero_tracker
-net_zero_tracker:9695003E4MMA10IBTR26:2030,9695003E4MMA10IBTR26,Absolute emission reduction,2030,2030,60,percent,https://www.gecina.fr/sites/default/files/2019-04/rapportclimat_gb_240716_1225.pdf,net_zero_tracker
-net_zero_tracker:969500A1YF1XUYYXS284:2030,969500A1YF1XUYYXS284,Absolute emission reduction,2017,2030,35,percent,https://www.se.com/ww/en/assets/564/document/322964/sustainability-report-2021.pdf,net_zero_tracker
-net_zero_tracker:969500AQW31GYO8JZD66:2030,969500AQW31GYO8JZD66,Absolute emission reduction,2019,2030,12,percent,https://corporate.airfrance.com/en/news/air-france-launches-its-air-france-act-programme-presenting-its-new-co2-emissions-reduction,net_zero_tracker
-net_zero_tracker:969500F7JLTX36OUI695:2030,969500F7JLTX36OUI695,Absolute emission reduction,2019,2030,50,percent,https://www.renaultgroup.com/wp-content/uploads/2021/04/220421_climate-report-renault-group_8mb.pdf,net_zero_tracker
-net_zero_tracker:969500LCBOG12HXPYM84:2025,969500LCBOG12HXPYM84,Absolute emission reduction,2017,2025,34,percent,https://www.sodexo.com/files/live/sites/com-global/files/02%20PDF/Finance/Sodexo-Integrated-Report-Fiscal-2020.pdf,net_zero_tracker
-net_zero_tracker:969500LENY69X51OOT31:2040,969500LENY69X51OOT31,Absolute emission reduction,2020,2040,100,percent,https://netzero.veolia.co.uk/our-commitments-and-road-map-uk-and-ireland/,net_zero_tracker
-net_zero_tracker:969500MCOONR8990S771:2025,969500MCOONR8990S771,Absolute emission reduction,2015,2025,30,percent,https://www.orange.com/en/environmental-commitment-orange-vows-achieve-net-zero-carbon-emissions-2040,net_zero_tracker
-net_zero_tracker:969500MMPQVHK671GT54:2035,969500MMPQVHK671GT54,Absolute emission reduction,2018,2035,33,percent,https://www.airliquide.com/sites/airliquide.com/files/2021/03/22/act-leaflet.pdf,net_zero_tracker
-net_zero_tracker:969500P8M3W2XX376054:2030,969500P8M3W2XX376054,Absolute emission reduction,2010,2030,40,percent,https://www.covivio.eu/en/wp-content/uploads/sites/3/2021/11/PR-Carbon-trajectory.pdf,net_zero_tracker
-net_zero_tracker:969500PB4U31KEFHZ621:2022,969500PB4U31KEFHZ621,Absolute emission reduction,2010,2022,40,percent,https://www.klepierre.com/en/finance/2020-universal-registration-document,net_zero_tracker
-net_zero_tracker:969500UIC89GT3UL7L24:2030,969500UIC89GT3UL7L24,Absolute emission reduction,2018,2030,50,percent,https://ungc-production.s3.us-west-2.amazonaws.com/attachments/cop_2020/487926/original/2019_SAFRAN__Integrated_Report.pdf?1596528297,net_zero_tracker
-net_zero_tracker:969500WP61NBK098AC47:2030,969500WP61NBK098AC47,Relative emission reduction,2016,2030,60,percent,https://www.groupeseb.com/en/climate-action,net_zero_tracker
-net_zero_tracker:969500XXRPGD7HCAFA90:2030,969500XXRPGD7HCAFA90,Absolute emission reduction,2016,2030,30,percent,https://www.legrandgroup.com/sites/default/files/Documents_PDF_Legrand/Finance/2021/autres/Legrand_URD_2020_1620039999.pdf,net_zero_tracker
-net_zero_tracker:9N3UAJSNOUXFKQLF3V18:2035,9N3UAJSNOUXFKQLF3V18,Absolute emission reduction,2010,2035,70,percent,https://pplweb.mediaroom.com/2021-08-05-PPL-Corporation-Reports-Second-Quarter-2021-Earnings-Announces-Net-Zero-Carbon-Emissions-Goal,net_zero_tracker
-net_zero_tracker:9ZHRYM6F437SQJ6OUG95:2030,9ZHRYM6F437SQJ6OUG95,Absolute emission reduction,2011,2030,40,percent,https://www.rbinternational.com/resources/RBI/raiffeisen-bank-international/sustainability/sustainability-report/RBI-Sustainability-Report-2020-EN-barrier-free-optimized.pdf,net_zero_tracker
-net_zero_tracker:AR5L2ODV9HN37376R084:2025,AR5L2ODV9HN37376R084,Absolute emission reduction,2016,2025,58,percent,https://www.mastercard.com/news/press/2021/january/mastercard-pledges-net-zero-emissions-innovates-for-collective-climate-action/,net_zero_tracker
-net_zero_tracker:BSYCX13Y0NOTV14V9N85:2040,BSYCX13Y0NOTV14V9N85,Absolute emission reduction,2016,2040,55,percent,https://www.repsol.com/content/dam/repsol-corporate/en_gb/accionistas-e-inversores/informes-anuales/2021/integrated-management-report-2021.pdf,net_zero_tracker
-net_zero_tracker:BUCRF72VH5RBN7X3VL35:2030,BUCRF72VH5RBN7X3VL35,Relative emission reduction,2000,2030,50,percent,https://www.entergy.com/environment/,net_zero_tracker
-net_zero_tracker:C4BXATY60WC6XEOZDX54:2030,C4BXATY60WC6XEOZDX54,Absolute emission reduction,2019,2030,30,percent,https://sustainabilityreport.metlife.com/content/dam/metlifecom/us/sustainability/pdf/report/2020/2020-sustainability-report.pdf,net_zero_tracker
-net_zero_tracker:CFGNEKW0P8842LEUIA51:2025,CFGNEKW0P8842LEUIA51,Absolute emission reduction,2009,2025,75,percent,https://www.pnc.com/content/dam/pnc-com/pdf/aboutpnc/CorporateResponsibilityReports/PNC_Corporate_Responsibility_Report_2021.pdf,net_zero_tracker
-net_zero_tracker:CUMYEZJOAF02RYZ1JJ85:2035,CUMYEZJOAF02RYZ1JJ85,Absolute emission reduction,2020,2035,40,percent,https://secure02.principal.com/publicvsupply/GetFile?fm=EE12496&ty=VOP,net_zero_tracker
-net_zero_tracker:CWAJJ9DJ5Z7P057HV541:2030,CWAJJ9DJ5Z7P057HV541,Absolute emission reduction,2017,2030,55,percent,https://www.vfc.com/sustainability-and-responsibility/climate,net_zero_tracker
-net_zero_tracker:CZ72ZHBVKZXQRV3XFE26:2021,CZ72ZHBVKZXQRV3XFE26,Absolute emission reduction,2019,2021,20,percent,https://sustainability.ovintiv.com/environment/emissions-and-climate-change/,net_zero_tracker
-net_zero_tracker:CZ72ZHBVKZXQRV3XFE26:2030,CZ72ZHBVKZXQRV3XFE26,Absolute emission reduction,2017,2030,20,percent,https://www.otsuka.com/en/csr/environment/climate.html,net_zero_tracker
-net_zero_tracker:D01LMJZU09ULLNCY6Z23:2035,D01LMJZU09ULLNCY6Z23,Absolute emission reduction,2020,2035,30,percent,https://www.edie.net/news/6/UPS-aims-for-carbon-neutral-by-2050/,net_zero_tracker
-net_zero_tracker:D71FAKCBLFS2O0RBPG08:2030,D71FAKCBLFS2O0RBPG08,Absolute emission reduction,2005,2030,56,percent,https://investor.williams.com/press-releases/press-release-details/2020/Williams-Announces-Goal-of-56-Absolute-Reduction-in-Greenhouse-Gas-Emissions-by-2030/default.aspx,net_zero_tracker
-net_zero_tracker:DX6GCWD4Q1JO9CRE5I40:2025,DX6GCWD4Q1JO9CRE5I40,Absolute emission reduction,2020,2025,55,percent,https://ugiesg.com/environment/,net_zero_tracker
-net_zero_tracker:E0JAN6VLUDI1HITHT809:2035,E0JAN6VLUDI1HITHT809,Absolute emission reduction,2016,2035,40,percent,https://www.chubb.com/content/dam/chubb-sites/chubb-com/us-en/about-chubb/environment/doc/Chubb_2021_Climate-Related_Financial_Disclosure_and_Environmental_Report.pdf,net_zero_tracker
-net_zero_tracker:F5WCUMTUM4RKZ1MAIE39:2030,F5WCUMTUM4RKZ1MAIE39,Absolute emission reduction,2010,2030,40,percent,https://www-axa-com.cdn.axa-contento-118412.eu/www-axa-com/7c51bab4-4266-42b6-aa8a-a6b209ee6e33_2019ClimateStrategy.pdf,net_zero_tracker
-net_zero_tracker:F8SB4JFBSYQFRQEH3Z21:2025,F8SB4JFBSYQFRQEH3Z21,Absolute emission reduction,2019,2025,51,percent,https://www.nab.com.au/about-us/social-impact/environment/climate-change,net_zero_tracker
-net_zero_tracker:FCNMH6O7VWU7LHXMK351:2025,FCNMH6O7VWU7LHXMK351,Relative emission reduction,2005,2025,20,percent,https://www.cabotcorp.com/-/media/files/reports/responsibility/cabot-corporation-sustainability-report-2021.pdf?la=en&rev=f75baea27ba94c0b8f6cae54ab91f2df,net_zero_tracker
-net_zero_tracker:FDPVHDGJ1IQZFK9KH630:2030,FDPVHDGJ1IQZFK9KH630,Absolute emission reduction,2017,2030,33,percent,https://www.eastman.com/Company/Sustainability/Documents/Eastman-Sustainability-Report-2020.pdf,net_zero_tracker
-net_zero_tracker:FGLT0EWZSUIRRITFOA30:2030,FGLT0EWZSUIRRITFOA30,Absolute emission reduction,2021,2030,25,percent,https://www.emerson.com/documents/corporate/emerson-2021-environmental-social-governance-report-en-us-8186672.pdf,net_zero_tracker
-net_zero_tracker:FJSUNZKFNQ5YPJ5OT455:2030,FJSUNZKFNQ5YPJ5OT455,Absolute emission reduction,2015,2030,75,percent,https://www.pepsico.com/our-impact/esg-topics-a-z/climate-change,net_zero_tracker
-net_zero_tracker:FR5LCKFTG8054YNNRU85:2025,FR5LCKFTG8054YNNRU85,Absolute emission reduction,2015,2025,25,percent,https://www.abbvie.com/content/dam/abbvie-dotcom/uploads/PDFs/AbbVie-Environmental_Stewardship-9.2016.pdf,net_zero_tracker
-net_zero_tracker:FXM8FAOHMYDIPD38UZ17:2030,FXM8FAOHMYDIPD38UZ17,Absolute emission reduction,2019,2030,95,percent,https://www.bookingholdings.com/wp-content/uploads/2022/03/BKNG-Sustainability-Report-2021.pdf,net_zero_tracker
-net_zero_tracker:GYVOE5EZ4GDAVTU4CQ61:2025,GYVOE5EZ4GDAVTU4CQ61,Absolute emission reduction,2015,2025,50,percent,https://www.analog.com/media/en/company-csr/adi-2020-corporate-responsibility-report.pdf,net_zero_tracker
-net_zero_tracker:HCHV7422L5HDJZCRFL38:2030,HCHV7422L5HDJZCRFL38,Absolute emission reduction,2020,2030,30,percent,https://thermofisher.mediaroom.com/2021-07-27-Thermo-Fisher-Scientific-Commits-to-Achieve-Net-Zero-Carbon-Emissions-by-2050,net_zero_tracker
-net_zero_tracker:HL3H1H2BGXWVG3BSWR90:2030,HL3H1H2BGXWVG3BSWR90,Absolute emission reduction,2019,2030,50,percent,https://www.pmi.com/sustainability/our-2025-roadmap,net_zero_tracker
-net_zero_tracker:HL5XPTVRV0O8TUN5LL90:2030,HL5XPTVRV0O8TUN5LL90,Absolute emission reduction,2000,2030,20,percent,https://corporate.bestbuy.com/best-buy-signs-the-climate-pledge-accelerating-sustainability-goals/,net_zero_tracker
-net_zero_tracker:HO1QNWM0IXBZ0QSMMO20:2030,HO1QNWM0IXBZ0QSMMO20,Absolute emission reduction,2020,2030,30,percent,https://corporate.ralphlauren.com/on/demandware.static/-/Sites-RalphLauren_Corporate-Library/default/dw7119005d/documents/2022-RL-GCSReport.pdf,net_zero_tracker
-net_zero_tracker:HV5W8PGLJ127N2SFSM23:2025,HV5W8PGLJ127N2SFSM23,Absolute emission reduction,2010,2025,20,percent,https://www.bkb.ch/de/-/media/bkb/website/pdf/berichte-und-praesentationen/bkb-strategie-2022plus.pdf,net_zero_tracker
-net_zero_tracker:I07WOS4YJ0N7YRFE7309:2030,I07WOS4YJ0N7YRFE7309,Absolute emission reduction,2019,2030,46,percent,https://investors.rtx.com/static-files/56ac9c22-51b0-43e4-a12e-842f9fdcf3fa,net_zero_tracker
-net_zero_tracker:I1BZKREC126H0VB1BL91:2030,I1BZKREC126H0VB1BL91,Absolute emission reduction,2005,2030,50,percent,https://www.duke-energy.com/our-company/esg/esg-report,net_zero_tracker
-net_zero_tracker:I9Q57JVPWHHZ3ZGBW498:2030,I9Q57JVPWHHZ3ZGBW498,Absolute emission reduction,2012,2030,65,percent,https://www.comerica.com/content/dam/comerica/en/documents/resources/about/sustainability/2020-comerica-cr-report-final.pdf,net_zero_tracker
-net_zero_tracker:ICE2EP6D98PQUILVRZ91:2030,ICE2EP6D98PQUILVRZ91,Absolute emission reduction,2019,2030,46,percent,https://investors.bd.com/static-files/3cd64f37-762a-4aa7-bd81-9b9030172dee,net_zero_tracker
-net_zero_tracker:IGJSJL3JD5P30I6NJZ34:2022,IGJSJL3JD5P30I6NJZ34,Absolute emission reduction,2012,2022,100,percent,https://www.morganstanley.com/ideas/climate-change-net-zero-financed-emissions,net_zero_tracker
-net_zero_tracker:ILUL7B6Z54MRYCF6H308:2030,ILUL7B6Z54MRYCF6H308,Absolute emission reduction,2010,2030,65,percent,https://news.dominionenergy.com/2022-02-11-Dominion-Energy-Broadens-Net-Zero-Commitments,net_zero_tracker
-net_zero_tracker:IOG4E947OATN0KJYSD45:2026,IOG4E947OATN0KJYSD45,Absolute emission reduction,2019,2026,50,percent,https://r.lvmh-static.com/uploads/2021/05/life_360_en_externe_def.pdf,net_zero_tracker
-net_zero_tracker:ISRPG12PN4EIEOEMW547:2024,ISRPG12PN4EIEOEMW547,Absolute emission reduction,2018,2024,10,percent,https://www.honeywell.com/content/dam/honeywellbt/en/documents/downloads/Hon-Corporate-Citizenship-Report.pdf,net_zero_tracker
-net_zero_tracker:IWUQB36BXD6OWD6X4T14:2035,IWUQB36BXD6OWD6X4T14,Absolute emission reduction,2019,2035,40,percent,https://www.aa.com/content/images/customer-service/about-us/corporate-governance/esg/aag-esg-report-2021.pdf,net_zero_tracker
-net_zero_tracker:J3WHBG0MTS7O8ZVMDC91:2030,J3WHBG0MTS7O8ZVMDC91,Absolute emission reduction,2016,2030,20,percent,https://corporate.exxonmobil.com/-/media/Global/Files/Advancing-Climate-Solutions-Progress-Report/2022/ExxonMobil-Advancing-Climate-Solutions-2022-Progress-Report.pdf?la=en&hash=AFC42B15F21ADB081F9A35AA685385A3287F48E5,net_zero_tracker
-net_zero_tracker:J48DJYXDTLHM30UMYI18:2030,J48DJYXDTLHM30UMYI18,Absolute emission reduction,2018,2030,40,percent,https://www.itochu.co.jp/en/csr/pdf/21fulle-all.pdf,net_zero_tracker
-net_zero_tracker:J5OIVXX3P24RJRW5CK77:2030,J5OIVXX3P24RJRW5CK77,Absolute emission reduction,2020,2030,25,percent,https://www.baxter.com/sites/g/files/ebysai3896/files/2022-06/Baxter_2021_Corporate_Responsibility_Report.pdf,net_zero_tracker
-net_zero_tracker:JNLUVFYJT1OZSIQ24U47:2030,JNLUVFYJT1OZSIQ24U47,Absolute emission reduction,2019,2030,20,percent,https://www.ussteel.com/media/newsroom/-/blogs/united-states-steel-corporation-announces-goal-to-achieve-carbon-neutrality-by-2050,net_zero_tracker
-net_zero_tracker:KVIPTY4PULAPGC1VVD26:2030,KVIPTY4PULAPGC1VVD26,Absolute emission reduction,2020,2030,50,percent,https://mitsubishicorp.disclosure.site/en/themes/113#917,net_zero_tracker
-net_zero_tracker:KY37LUS27QQX7BB93L28:2030,KY37LUS27QQX7BB93L28,Absolute emission reduction,2018,2030,50,percent,https://www.nestle.com/sites/default/files/2022-03/2021-annual-review-en.pdf,net_zero_tracker
-net_zero_tracker:L47NHHI0Z9X22DV46U41:2025,L47NHHI0Z9X22DV46U41,Absolute emission reduction,2018,2025,30,percent,https://www.beiersdorf.com/newsroom/press-releases/all-press-releases/2019/12/17-beiersdorf-implements-ambitious-climate-target,net_zero_tracker
-net_zero_tracker:LAXUQCHT4FH58LRZDY46:2030,LAXUQCHT4FH58LRZDY46,Absolute emission reduction,2018,2030,25,percent,https://www.eni.com/en-IT/low-carbon/strategy-climate-change.html,net_zero_tracker
-net_zero_tracker:LGJNMI9GH8XIDG5RCM61:2030,LGJNMI9GH8XIDG5RCM61,Absolute emission reduction,2005,2030,80,percent,https://www.xcelenergy.com/staticfiles/xe-responsive/Company/Sustainability%20Report/2021%20SR/2021-Sustainability-Report-Full.pdf,net_zero_tracker
-net_zero_tracker:LONOZNOJYIBXOHXWDB86:2030,LONOZNOJYIBXOHXWDB86,Absolute emission reduction,2015,2030,45,percent,https://betterdays.kelloggcompany.com/climate-action,net_zero_tracker
-net_zero_tracker:LUZQVYP4VS22CLWDAR65:2030,LUZQVYP4VS22CLWDAR65,Absolute emission reduction,2019,2030,50,percent,https://multimedia.3m.com/mws/media/2006067O/3m-sustainability-2021-brochure.pdf,net_zero_tracker
-net_zero_tracker:LZ2C6E0W5W7LQMX5ZI37:2020,LZ2C6E0W5W7LQMX5ZI37,Relative emission reduction,1990,2020,23,percent,https://www.heidelbergcement.com/de/energie-und-klimaschutz,net_zero_tracker
-net_zero_tracker:M1YXUUZR0EIMU8T0EM75:2025,M1YXUUZR0EIMU8T0EM75,Absolute emission reduction,2015,2025,100,percent,https://www.astrazeneca.com/content/dam/az/Investor_Relations/annual-report-2021/pdf/AstraZeneca_AR_2021.pdf,net_zero_tracker
-net_zero_tracker:M312WZV08Y7LYUC71685:2030,M312WZV08Y7LYUC71685,Absolute emission reduction,2019,2030,60,percent,https://www.swedbank.com/sustainability/environment/climate.html,net_zero_tracker
-net_zero_tracker:MP3J6QPYPGN75NVW2S34:2021,MP3J6QPYPGN75NVW2S34,Absolute emission reduction,2015,2021,40,percent,https://www.kimberly-clark.com/en-us/esg/downloads,net_zero_tracker
-net_zero_tracker:MSFSBD3QN1GSN7Q6C537:2030,MSFSBD3QN1GSN7Q6C537,Absolute emission reduction,2020,2030,42,percent,https://www.commbank.com.au/content/dam/commbank-assets/about-us/2021-08/2021-annual-report_spreads.pdf#page=12,net_zero_tracker
-net_zero_tracker:MZK1AT00SJV4XB7WNL71:2030,MZK1AT00SJV4XB7WNL71,Absolute emission reduction,2019,2030,46,percent,https://www.merck.com/wp-content/uploads/sites/5/2021/09/Merck-ESG-Report.pdf,net_zero_tracker
-net_zero_tracker:N1GZ7BBF3NP8GI976H15:2029,N1GZ7BBF3NP8GI976H15,Absolute emission reduction,2014,2029,40,percent,https://www.usbank.com/about-us-bank/community/sustainability.html,net_zero_tracker
-net_zero_tracker:NFONVGN05Z0FMN5PEC35:2030,NFONVGN05Z0FMN5PEC35,Absolute emission reduction,2017,2030,33,percent,https://www.saint-gobain.com/sites/saint-gobain.com/files/media/document/2021-06/universal.pdf,net_zero_tracker
-net_zero_tracker:NNROIXVWJ7CPSR27SV97:2020,NNROIXVWJ7CPSR27SV97,Relative emission reduction,2016,2020,6,percent,nan,net_zero_tracker
-net_zero_tracker:OQSJ1DU9TAOC51A47K68:2030,OQSJ1DU9TAOC51A47K68,Absolute emission reduction,2019,2030,50,percent,https://stories.starbucks.com/uploads/2022/04/Starbucks-2021-Global-Environmental-and-Social-Impact-Report-1.pdf,net_zero_tracker
-net_zero_tracker:PBBKGKLRK5S5C0Y4T545:2030,PBBKGKLRK5S5C0Y4T545,Absolute emission reduction,2019,2030,50,percent,https://www.sempra.com/sites/default/files/content/files/node-report/2020/SempraEnergy_2020_Corporate-Sustainability-Report.pdf,net_zero_tracker
-net_zero_tracker:PY6ZZQWO2IZFZC3IOL08:2025,PY6ZZQWO2IZFZC3IOL08,Absolute emission reduction,2015,2025,100,percent,https://www.astrazeneca.com/content/dam/az/Sustainability/2021/pdf/Sustainability_Report_2020.pdf,net_zero_tracker
-net_zero_tracker:Q9MAIUP40P25UFBFG033:2030,Q9MAIUP40P25UFBFG033,Absolute emission reduction,2019,2030,75,percent,https://www.eon.com/content/dam/eon/eon-com/eon-com-assets/documents/sustainability/en/climate-related-disclosures/EON_2022_On_course_for_net_zero.pdf,net_zero_tracker
-net_zero_tracker:QEKMOTMBBKA8I816DO57:2030,QEKMOTMBBKA8I816DO57,Absolute emission reduction,2009,2030,40,percent,https://corporate.homedepot.com/responsibility/protecting-the-climate,net_zero_tracker
-net_zero_tracker:R4PP93JZOLY261QX3811:2020,R4PP93JZOLY261QX3811,Absolute emission reduction,2011,2020,56,percent,https://about.americanexpress.com/corporate-responsibility/sustainability/sustainability/default.aspx,net_zero_tracker
-net_zero_tracker:RCGZFPDMRW58VJ54VR07:2030,RCGZFPDMRW58VJ54VR07,Absolute emission reduction,2018,2030,50,percent,https://s23.q4cdn.com/574569502/files/doc_governance/2022/Salesforce-ES-Schedules-FY22-EYReport.pdf,net_zero_tracker
-net_zero_tracker:RIFQSET379FOGTEFKS80:2030,RIFQSET379FOGTEFKS80,Absolute emission reduction,2019,2030,50,percent,https://www.franklinresources.com/ftresources/investor-relations/annual-report#maintaining-fiscal-responsibility-,net_zero_tracker
-net_zero_tracker:RIMU48P07456QXSO0R61:2020,RIMU48P07456QXSO0R61,Absolute emission reduction,2010,2020,30,percent,https://www.northropgrumman.com/wp-content/uploads/2021-NG-Sustainability-Report_Final.pdf,net_zero_tracker
-net_zero_tracker:RVHJWBXLJ1RFUBSY1F30:2025,RVHJWBXLJ1RFUBSY1F30,Absolute emission reduction,2017,2025,25,percent,https://www.boeing.com/resources/boeingdotcom/principles/sustainability/assets/data/2021_Boeing_Sustainability_Report.pdf,net_zero_tracker
-net_zero_tracker:SQ95QG8SR5Q56LSNF682:2030,SQ95QG8SR5Q56LSNF682,Absolute emission reduction,2019,2030,46,percent,https://www.illumina.com/content/dam/illumina-marketing/documents/company/illumina-csr-report-2022.pdf,net_zero_tracker
-net_zero_tracker:T2ZG1WRWZ4BUCMQL9224:2030,T2ZG1WRWZ4BUCMQL9224,Absolute emission reduction,2017,2030,90,percent,https://www.gapinc.com/en-us/values/sustainability/environment/energy-climate,net_zero_tracker
-net_zero_tracker:TL2N6M87CW970S5SV098:2025,TL2N6M87CW970S5SV098,Absolute emission reduction,2017,2025,24,percent,https://www.naturgy.com/files/Taxonomia_ENG.pdf,net_zero_tracker
-net_zero_tracker:TSI2PJM6EPETEQ4X1U25:2025,TSI2PJM6EPETEQ4X1U25,Absolute emission reduction,2019,2025,70,percent,https://www.infineon.com/dgdl/Sustainability+at+Infineon+Supplementing+the+Annual+Report+2021.pdf?fileId=8ac78c8b7d507352017d6b57a9f6016c,net_zero_tracker
-net_zero_tracker:UE2136O97NLB5BYP9H04:2030,UE2136O97NLB5BYP9H04,Absolute emission reduction,2015,2030,36,percent,https://corporate.mcdonalds.com/content/dam/gwscorp/assets/our-planet/climate-action/McDonalds-2021-Climate-Risk-and-Resiliency-Summary.pdf,net_zero_tracker
-net_zero_tracker:UWJKFUJFZ02DKWI3RY53:2030,UWJKFUJFZ02DKWI3RY53,Absolute emission reduction,2015,2030,25,percent,https://www.coca-colacompany.com/content/dam/journey/us/en/reports/coca-cola-business-environmental-social-governance-report-2021.pdf,net_zero_tracker
-net_zero_tracker:VGRQXHF3J8VDLUA7XE92:2025,VGRQXHF3J8VDLUA7XE92,Absolute emission reduction,2010,2025,65,percent,https://www.ibm.com/ibm/environment/annual/IBMEnvReport_2020.pdf,net_zero_tracker
-net_zero_tracker:W38RGI023J3WT1HWRP32:2030,W38RGI023J3WT1HWRP32,Absolute emission reduction,2020,2030,20,percent,https://assets.new.siemens.com/siemens/assets/api/uuid:4806da09-01c7-40b1-af91-99af4b726653/sustainability2021-en.pdf,net_zero_tracker
-net_zero_tracker:W8J5WZB5IY3K0NDQT671:2032,W8J5WZB5IY3K0NDQT671,Absolute emission reduction,2019,2032,55,percent,https://www.biogen.com/en_us/healthy-climate-healthy-lives.html,net_zero_tracker
-net_zero_tracker:WAFCR4OKGSC504WU3E95:2025,WAFCR4OKGSC504WU3E95,Absolute emission reduction,2016,2025,40,percent,https://corporate.lowes.com/sites/lowes-corp/files/2021-07/2020_CSR_FINAL.pdf,net_zero_tracker
-net_zero_tracker:WD6L6041MNRW1JE49D58:2030,WD6L6041MNRW1JE49D58,Absolute emission reduction,2016,2030,30,percent,https://www.tysonfoods.com/news/news-releases/2021/6/tyson-foods-targets-2050-achieve-net-zero-greenhouse-gas-emissions,net_zero_tracker
-net_zero_tracker:WFLLPEPC7FZXENRZV188:2025,WFLLPEPC7FZXENRZV188,Absolute emission reduction,2018,2025,20,percent,https://www.bnymellon.com/content/dam/bnymellon/documents/pdf/2020-enterprise-esg-report.pdf.coredownload.pdf,net_zero_tracker
-net_zero_tracker:WHENKOULSSK7WUM60H03:2030,WHENKOULSSK7WUM60H03,Absolute emission reduction,2016,2030,20,percent,https://whirlpoolcorp.com/2021SustainabilityReport/downloads/whirlpool_2021_sr.pdf,net_zero_tracker
-net_zero_tracker:WPTL2Z3FIYTHSP5V2253:2030,WPTL2Z3FIYTHSP5V2253,Relative emission reduction,2016,2030,50,percent,https://www.conocophillips.com/sustainability/managing-climate-related-risks/metrics-targets/ghg-target/,net_zero_tracker
-net_zero_tracker:XRZQ5S7HYJFPHJ78L959:2030,XRZQ5S7HYJFPHJ78L959,Absolute emission reduction,2005,2030,50,percent,https://ameren.mediaroom.com/2020-09-28-Ameren-establishes-net-zero-carbon-emissions-goal-and-a-transformative-expansion-of-wind-and-solar-energy,net_zero_tracker
-net_zero_tracker:XSGZFLO9YTNO9VCQV219:2030,XSGZFLO9YTNO9VCQV219,Absolute emission reduction,2017,2030,55,percent,https://www.altria.com/en/responsibility/protect-the-environment,net_zero_tracker
-net_zero_tracker:XWTZDRYZPBUHIQBKDB46:2025,XWTZDRYZPBUHIQBKDB46,Relative emission reduction,2020,2025,0,percent,https://www.eogresources.com/sustainability/,net_zero_tracker
-net_zero_tracker:Y6X4K52KMJMZE7I7MY94:2025,Y6X4K52KMJMZE7I7MY94,Absolute emission reduction,2019,2025,25,percent,https://www.spglobal.com/esg/insights/the-journey-to-net-zero-at-sp-global,net_zero_tracker
-net_zero_tracker:Y87794H0US1R65VBXU25:2025,Y87794H0US1R65VBXU25,Absolute emission reduction,2015,2025,35,percent,https://corporate.walmart.com/esgreport/esg-issues/climate-change,net_zero_tracker
-net_zero_tracker:YMEGZFW4SBUSS5BQXF88:2030,YMEGZFW4SBUSS5BQXF88,Absolute emission reduction,2020,2030,42,percent,https://www.colgatepalmolive.com/content/dam/cp-sites/corporate/corporate/common/pdf/sustainability/colgate-palmolive-sustainability-and-social-impact-final-report-2021.pdf,net_zero_tracker
-net_zero_tracker:ZUNI8PYC725B6H8JU438:2030,ZUNI8PYC725B6H8JU438,Absolute emission reduction,2019,2030,25,percent,https://www.cummins.com/sites/default/files/2021-05/cummins-tcfd-report-05-19-2021.pdf,net_zero_tracker
+net_zero_tracker:AO:2030,AO,Absolute emission reduction,2015.0,2030,21.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Angola%20First/NDC%20Angola.pdf,net_zero_tracker
+net_zero_tracker:BA:2050,BA,Absolute emission reduction,2014.0,2050,50.0,percent,https://www.climatewatchdata.org/ndcs/country/BIH?document=revised_first_ndc,net_zero_tracker
+net_zero_tracker:DM:2030,DM,Absolute emission reduction,2014.0,2030,45.0,percent,https://unfccc.int/sites/default/files/2022-07/The%20Commonwealth%20of%20Dominica%20updated%20NDC%20July%204%20%2C.pdf,net_zero_tracker
+net_zero_tracker:GQ:2050,GQ,Absolute emission reduction,2010.0,2050,50.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Equatorial%20Guinea%20First/Rep%C3%BAblica%20de%20Guinea%20Ecuatorial_INDC.pdf,net_zero_tracker
+net_zero_tracker:KN:2030,KN,Absolute emission reduction,2010.0,2030,61.0,percent,https://unfccc.int/sites/default/files/NDC/2022-06/St.%20Kitts%20and%20Nevis%20Revised%20NDC_Updated.pdf,net_zero_tracker
+net_zero_tracker:LC:2030,LC,Relative emission reduction,2030.0,2030,23.0,percent,https://unfccc.int/sites/default/files/NDC/2022-06/Saint%20Lucia%20First%20NDC%20%28Updated%20submission%29.pdf,net_zero_tracker
+net_zero_tracker:MK:2030,MK,Absolute emission reduction,1990.0,2030,82.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/The%20Republic%20of%20North%20Macedonia%20First/Macedonian%20enhanced%20NDC%20(002).pdf,net_zero_tracker
+net_zero_tracker:NL:2050,NL,Absolute emission reduction,1990.0,2050,95.0,percent,https://www.cbs.nl/en-gb/news/2022/06/urgenda-reduction-target-for-ghg-emissions-achieved-in-2020,net_zero_tracker
+net_zero_tracker:NO:2050,NO,Absolute emission reduction,1990.0,2050,95.0,percent,https://unfccc.int/sites/default/files/NDC/2022-11/NDC%20Norway_second%20update.pdf,net_zero_tracker
+net_zero_tracker:PY:2030,PY,Relative emission reduction,2030.0,2030,20.0,percent,http://www.mades.gov.py/wp-content/uploads/2021/07/ACTUALIZACION-DE-LA-NDC-DEL-PARAGUAY_Borrador-final_Julio-2021-1.pdf,net_zero_tracker
+net_zero_tracker:UG:2030,UG,Relative emission reduction,2030.0,2030,24.0,percent,https://unfccc.int/sites/default/files/NDC/2022-09/Updated%20NDC%20_Uganda_2022%20Final.pdf,net_zero_tracker
+net_zero_tracker:AD:2030,AD,Relative emission reduction,2030.0,2030,55.0,percent,https://unfccc.int/sites/default/files/NDC/2022-11/20222410_Actualitzacio%20NDC.pdf,net_zero_tracker
+net_zero_tracker:AE:2030,AE,Relative emission reduction,2030.0,2030,31.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/United%20Arab%20Emirates%20Second/UAE%20Second%20NDC%20-%20UNFCCC%20Submission%20-%20English%20-%20FINAL.pdf,net_zero_tracker
+net_zero_tracker:AF:2030,AF,Relative emission reduction,2030.0,2030,13.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:AM:2030,AM,Absolute emission reduction,1990.0,2030,40.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Armenia%20First/NDC%20of%20Republic%20of%20Armenia%20%202021-2030.pdf,net_zero_tracker
+net_zero_tracker:AO:2025,AO,Absolute emission reduction,2015.0,2025,14.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Angola%20First/NDC%20Angola.pdf,net_zero_tracker
+net_zero_tracker:AT:2030,AT,Absolute emission reduction,1990.0,2030,55.0,percent,https://www.climatewatchdata.org/countries/AUT?end_year=2018&start_year=1990#ndc-content-overview,net_zero_tracker
+net_zero_tracker:AU:2030,AU,Absolute emission reduction,2005.0,2030,43.0,percent,https://unfccc.int/sites/default/files/NDC/2022-06/Australias%20NDC%20June%202022%20Update%20%283%29.pdf,net_zero_tracker
+net_zero_tracker:BA:2030,BA,Absolute emission reduction,2014.0,2030,12.0,percent,https://www.climatewatchdata.org/ndcs/country/BIH?document=revised_first_ndc,net_zero_tracker
+net_zero_tracker:BB:2030,BB,Absolute emission reduction,2008.0,2030,70.0,percent,https://htmlpreview.github.io/?https://github.com/WRI-ClimateWatch/ndc/blob/master/BRB-revised_first_ndc-EN.html,net_zero_tracker
+net_zero_tracker:BD:2030,BD,Absolute emission reduction,2012.0,2030,15.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Bangladesh%20First/NDC_submission_20210826revised.pdf,net_zero_tracker
+net_zero_tracker:BE:2030,BE,Absolute emission reduction,1990.0,2030,55.0,percent,https://unfccc.int/sites/default/files/resource/LTS_BE_EN_summary.pdf,net_zero_tracker
+net_zero_tracker:BF:2030,BF,Relative emission reduction,2030.0,2030,11.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:BG:2030,BG,Absolute emission reduction,1990.0,2030,40.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/12/1312-Annex-Alliance-ENGLISH-VF-2012.pdf,net_zero_tracker
+net_zero_tracker:BI:2030,BI,Relative emission reduction,2030.0,2030,20.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/12/1312-Annex-Alliance-ENGLISH-VF-2012.pdf,net_zero_tracker
+net_zero_tracker:BR:2025,BR,Absolute emission reduction,2005.0,2025,37.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Brazil%20First/2021%20-%20Carta%20MRE.pdf,net_zero_tracker
+net_zero_tracker:BS:2030,BS,Relative emission reduction,2030.0,2030,30.0,percent,https://unfccc.int/sites/default/files/NDC/2022-11/Bahamas%20Updated%20Nationally%20Determined%20Contributio,net_zero_tracker
+net_zero_tracker:CA:2030,CA,Absolute emission reduction,2005.0,2030,45.0,percent,https://www.canada.ca/en/services/environment/weather/climatechange/climate-plan/net-zero-emissions-2050.html,net_zero_tracker
+net_zero_tracker:CF:2030,CF,Relative emission reduction,2030.0,2030,24.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:CG:2025,CG,Absolute emission reduction,2017.0,2025,48.0,percent,https://ndcpartnership.org/countries-map/country?iso=COG,net_zero_tracker
+net_zero_tracker:CH:2030,CH,Absolute emission reduction,1990.0,2030,50.0,percent,https://www.admin.ch/gov/en/start/documentation/media-releases.msg-id-82140.html,net_zero_tracker
+net_zero_tracker:CN:2030,CN,Relative emission reduction,2005.0,2030,65.0,percent,https://unfccc.int/sites/default/files/NDC/2022-11/Progress%20of%20China%20NDC%202022.pdf,net_zero_tracker
+net_zero_tracker:CO:2030,CO,Relative emission reduction,2030.0,2030,51.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Colombia%20First/NDC%20actualizada%20de%20Colombia.pdf,net_zero_tracker
+net_zero_tracker:CV:2030,CV,Relative emission reduction,2030.0,2030,24.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Cabo%20Verde%20First/Cabo%20Verde_NDC%20Update%202021.pdf,net_zero_tracker
+net_zero_tracker:CY:2030,CY,Absolute emission reduction,1990.0,2030,55.0,percent,https://ec.europa.eu/energy/sites/default/files/documents/cy_final_necp_main_en.pdf,net_zero_tracker
+net_zero_tracker:DE:2030,DE,Absolute emission reduction,1990.0,2030,65.0,percent,https://www.bundesregierung.de/breg-de/themen/klimaschutz/climate-change-act-2021-1936846,net_zero_tracker
+net_zero_tracker:DK:2030,DK,Absolute emission reduction,1990.0,2030,70.0,percent,https://en.kefm.dk/news/news-archive/2019/dec/during-the-cop-denmark-passes-climate-act-with-a-70-percent-reduction-targetws-page-eng,net_zero_tracker
+net_zero_tracker:DM:2025,DM,Absolute emission reduction,2014.0,2025,39.0,percent,https://unfccc.int/sites/default/files/2022-07/The%20Commonwealth%20of%20Dominica%20updated%20NDC%20July%204%20%2C.pdf,net_zero_tracker
+net_zero_tracker:DO:2030,DO,Relative emission reduction,2030.0,2030,27.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Dominican%20Republic%20First/INDC-DR%20August%202015%20(unofficial%20translation).pdf,net_zero_tracker
+net_zero_tracker:EE:2030,EE,Absolute emission reduction,1990.0,2030,70.0,percent,https://www.europarl.europa.eu/thinktank/de/document.html?reference=EPRS_BRI%282021%29690684,net_zero_tracker
+net_zero_tracker:ER:2025,ER,Absolute emission reduction,2010.0,2025,6.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/12/1312-Annex-Alliance-ENGLISH-VF-2012.pdf,net_zero_tracker
+net_zero_tracker:ES:2030,ES,Absolute emission reduction,1990.0,2030,23.0,percent,https://boe.es/buscar/act.php?id=BOE-A-2021-8447#top,net_zero_tracker
+net_zero_tracker:ET:2030,ET,Relative emission reduction,2030.0,2030,68.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Ethiopia%20First/Ethiopia%27s%20updated%20NDC%20JULY%202021%20Submission_.pdf,net_zero_tracker
+net_zero_tracker:FI:2030,FI,Absolute emission reduction,2005.0,2030,55.0,percent,https://ym.fi/en/finland-s-national-climate-change-policy,net_zero_tracker
+net_zero_tracker:FM:2025,FM,Absolute emission reduction,2000.0,2025,28.0,percent,https://unfccc.int/sites/default/files/NDC/2022-10/Updated_NDC_of_the_Federated_States_of_Micronesia.pdf,net_zero_tracker
+net_zero_tracker:FR:2030,FR,Absolute emission reduction,1990.0,2030,55.0,percent,https://www.climatewatchdata.org/countries/FRA,net_zero_tracker
+net_zero_tracker:GB:2030,GB,Absolute emission reduction,1990.0,2030,68.0,percent,https://unfccc.int/sites/default/files/NDC/2022-09/UK%20NDC%20ICTU%202022.pdf,net_zero_tracker
+net_zero_tracker:GD:2025,GD,Absolute emission reduction,2010.0,2025,30.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Grenada%20Second/GrenadaSecondNDC2020%20-%2001-12-20.pdf,net_zero_tracker
+net_zero_tracker:GM:2030,GM,Relative emission reduction,2030.0,2030,49.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Gambia%20Second%20NDC/Second%20NDC%20of%20The%20Republic%20of%20The%20Gambia.pdf,net_zero_tracker
+net_zero_tracker:GN:2030,GN,Absolute emission reduction,1994.0,2030,13.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:GQ:2030,GQ,Absolute emission reduction,2010.0,2030,20.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Equatorial%20Guinea%20First/Rep%C3%BAblica%20de%20Guinea%20Ecuatorial_INDC.pdf,net_zero_tracker
+net_zero_tracker:GR:2030,GR,Absolute emission reduction,2021.0,2030,55.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Greece%20First/EU_NDC_Submission_December%202020.pdf,net_zero_tracker
+net_zero_tracker:GW:2030,GW,Relative emission reduction,2030.0,2030,30.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Guinea-Bissau%20First/NDC-Guinea%20Bissau-12102021.Final.pdf,net_zero_tracker
+net_zero_tracker:HR:2030,HR,Absolute emission reduction,1990.0,2030,36.0,percent,https://mingor.gov.hr/UserDocsImages/klimatske_aktivnosti/odrzivi_razvoj/NUS/lts_nus_eng.pdf,net_zero_tracker
+net_zero_tracker:HT:2030,HT,Relative emission reduction,2030.0,2030,6.0,percent,https://unfccc.int/sites/default/files/NDC/2022-06/CDN%20Revisee%20Haiti%202022.pdf,net_zero_tracker
+net_zero_tracker:HU:2030,HU,Absolute emission reduction,1990.0,2030,40.0,percent,https://www.parlament.hu/irom41/07021/07021-0010.pdf,net_zero_tracker
+net_zero_tracker:ID:2030,ID,Absolute emission reduction,2030.0,2030,29.0,percent,https://unfccc.int/sites/default/files/NDC/2022-09/ENDC%20Indonesia.pdf,net_zero_tracker
+net_zero_tracker:IE:2030,IE,Absolute emission reduction,1990.0,2030,55.0,percent,https://static.rasset.ie/documents/news/2020/06/draft-programme-for-govt.pdfhttps://www.gov.ie/pdf/?file=https://assets.gov.ie/42213/752d5346b9c6407b9125fdadfa0738a4.pdf#page=1,net_zero_tracker
+net_zero_tracker:IL:2030,IL,Absolute emission reduction,2015.0,2030,27.0,percent,https://www.jpost.com/climate-change/cop26-israel-to-aim-for-zero-net-emissions-by-2050-683470,net_zero_tracker
+net_zero_tracker:IN:2030,IN,Relative emission reduction,2005.0,2030,45.0,percent,https://unfccc.int/sites/default/files/NDC/2022-08/India%20Updated%20First%20Nationally%20Determined%20Contrib.pdf,net_zero_tracker
+net_zero_tracker:IS:2030,IS,Absolute emission reduction,1990.0,2030,55.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Iceland%20First/Iceland_updated_NDC_Submission_Feb_2021.pdf,net_zero_tracker
+net_zero_tracker:IT:2030,IT,Absolute emission reduction,1990.0,2030,55.0,percent,https://ec.europa.eu/clima/sites/lts/lts_it_it.pdf,net_zero_tracker
+net_zero_tracker:JP:2030,JP,Absolute emission reduction,2013.0,2030,46.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Japan%20First/JAPAN_FIRST%20NDC%20(INTERIM-UPDATED%20SUBMISSION).pdf,net_zero_tracker
+net_zero_tracker:KG:2030,KG,Relative emission reduction,2030.0,2030,29.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Kyrgyzstan%20First/Kyrgyzstan%20INDC%20_ENG_%20final.pdf,net_zero_tracker
+net_zero_tracker:KH:2030,KH,Relative emission reduction,2030.0,2030,41.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:KM:2030,KM,Relative emission reduction,2030.0,2030,23.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:KR:2030,KR,Absolute emission reduction,2018.0,2030,40.0,percent,https://unfccc.int/sites/default/files/NDC/2022-06/211223_The%20Republic%20of%20Korea%27s%20Enhanced%20Update%20of%20its%20First%20Nationally%20Determined%20Contribution_211227_editorial%20change.pdf,net_zero_tracker
+net_zero_tracker:KZ:2030,KZ,Absolute emission reduction,1990.0,2030,25.0,percent,https://legalacts.egov.kz/npa/view?id=11488215,net_zero_tracker
+net_zero_tracker:LA:2030,LA,Relative emission reduction,2030.0,2030,60.0,percent,"https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Lao%20People%27s%20Democratic%20Republic%20First/NDC%202020%20of%20Lao%20PDR%20(English),%2009%20April%202021%20(1).pdf",net_zero_tracker
+net_zero_tracker:LB:2030,LB,Relative emission reduction,2030.0,2030,31.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Lebanon%20First/Lebanon%27s%202020%20Nationally%20Determined%20Contribution%20Update.pdf,net_zero_tracker
+net_zero_tracker:LC:2025,LC,Relative emission reduction,2025.0,2025,16.0,percent,https://unfccc.int/sites/default/files/NDC/2022-06/Saint%20Lucia%20First%20NDC%20%28Updated%20submission%29.pdf,net_zero_tracker
+net_zero_tracker:LR:2030,LR,Relative emission reduction,2030.0,2030,10.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Liberia%20First/INDC%20Final%20Submission%20Sept%2030%202015%20Liberia.pdf,net_zero_tracker
+net_zero_tracker:LS:2030,LS,Absolute emission reduction,2015.0,2030,35.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Lesotho%20First/Lesotho%20First%20NDC.pdf,net_zero_tracker
+net_zero_tracker:LT:2030,LT,Absolute emission reduction,1990.0,2030,55.0,percent,https://www.oecd-ilibrary.org/environment/oecd-environmental-performance-reviews-lithuania-2021_48d82b17-en,net_zero_tracker
+net_zero_tracker:LU:2030,LU,Absolute emission reduction,2005.0,2030,55.0,percent,"https://legilux.public.lu/eli/etat/leg/loi/2020/12/15/a994/jo#:~:text=La%20pr%C3%A9sente%20loi%20%C3%A9tablit%20un,par%20rapport%20aux%20niveaux%20pr%C3%A9industriels.",net_zero_tracker
+net_zero_tracker:LV:2030,LV,Absolute emission reduction,1990.0,2030,40.0,percent,https://ec.europa.eu/clima/sites/lts/lts_lv_en.pdf,net_zero_tracker
+net_zero_tracker:MC:2030,MC,Absolute emission reduction,1990.0,2030,55.0,percent,https://www.docdroid.net/gavlB6o/190922-rmi-unsg-summit-release-leaders-statement-final-combined-pdf,net_zero_tracker
+net_zero_tracker:MG:2030,MG,Relative emission reduction,2030.0,2030,32.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Madagascar%20First/Madagascar%20INDC%20Eng.pdf,net_zero_tracker
+net_zero_tracker:MH:2025,MH,Absolute emission reduction,2010.0,2025,32.0,percent,https://unfccc.int/sites/default/files/resource/180924%20rmi%202050%20climate%20strategy%20final_0.pdf,net_zero_tracker
+net_zero_tracker:ML:2030,ML,Relative emission reduction,2030.0,2030,22.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/12/1312-Annex-Alliance-ENGLISH-VF-2012.pdf,net_zero_tracker
+net_zero_tracker:MR:2030,MR,Relative emission reduction,2030.0,2030,11.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Mauritania%20First/CDN-actualis%C3%A9%202021_%20Mauritania.pdf,net_zero_tracker
+net_zero_tracker:MT:2030,MT,Absolute emission reduction,2005.0,2030,19.0,percent,https://meae.gov.mt/en/Public_Consultations/MECP/PublishingImages/Pages/Consultations/MaltasLowCarbonDevelopmentStrategy/Malta%20Low%20Carbon%20Development%20Strategy.pdf,net_zero_tracker
+net_zero_tracker:MU:2030,MU,Relative emission reduction,2030.0,2030,40.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Mauritius%20First/Final%20INDC%20for%20Mauritius%2028%20Sept%202015.pdf,net_zero_tracker
+net_zero_tracker:MW:2030,MW,Relative emission reduction,2030.0,2030,50.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Malawi%20First/Malawi%20NDC_Policy%20Brief_30%20June%202021.pdf,net_zero_tracker
+net_zero_tracker:MX:2030,MX,Absolute emission reduction,2000.0,2030,35.0,percent,https://unfccc.int/sites/default/files/NDC/2022-11/Mexico_NDC_UNFCCC_update2022_FINAL.pdf,net_zero_tracker
+net_zero_tracker:MY:2030,MY,Relative emission reduction,2005.0,2030,45.0,percent,https://rmke12.epu.gov.my/en,net_zero_tracker
+net_zero_tracker:NA:2030,NA,Relative emission reduction,2030.0,2030,91.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Namibia%20First/Namibia%27s%20Updated%20NDC_%20FINAL%2025%20July%202021.pdf,net_zero_tracker
+net_zero_tracker:NG:2030,NG,Relative emission reduction,2030.0,2030,47.0,percent,https://www.bloomberg.com/news/articles/2021-11-02/nigeria-targets-to-reach-net-zero-emissions-by-2060-buhari-says,net_zero_tracker
+net_zero_tracker:NL:2030,NL,Absolute emission reduction,1990.0,2030,49.0,percent,https://www.cbs.nl/en-gb/news/2022/06/urgenda-reduction-target-for-ghg-emissions-achieved-in-2020,net_zero_tracker
+net_zero_tracker:NO:2030,NO,Absolute emission reduction,1990.0,2030,55.0,percent,https://unfccc.int/sites/default/files/NDC/2022-11/NDC%20Norway_second%20update.pdf,net_zero_tracker
+net_zero_tracker:OM:2030,OM,Relative emission reduction,2030.0,2030,7.0,percent,https://www.muscatdaily.com/2022/10/11/oman-commits-to-net-zero-by-2050/,net_zero_tracker
+net_zero_tracker:PK:2030,PK,Relative emission reduction,2030.0,2030,50.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Pakistan%20First/Pakistan%20Updated%20NDC%202021.pdf,net_zero_tracker
+net_zero_tracker:PT:2030,PT,Absolute emission reduction,2020.0,2030,40.0,percent,https://unfccc.int/sites/default/files/resource/HR-03-06-2020%20EU%20Submission%20on%20Long%20term%20strategy.pdf,net_zero_tracker
+net_zero_tracker:PW:2025,PW,Relative emission reduction,2025.0,2025,48.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Palau%20First/Palau_INDC.Final%20Copy.pdf,net_zero_tracker
+net_zero_tracker:RO:2030,RO,Absolute emission reduction,2005.0,2030,44.0,percent,https://ec.europa.eu/energy/sites/default/files/documents/ro_final_necp_main_en.pdf,net_zero_tracker
+net_zero_tracker:RU:2030,RU,Absolute emission reduction,1990.0,2030,70.0,percent,http://static.government.ru/media/files/ADKkCzp3fWO32e2yA0BhtIpyzWfHaiUa.pdf,net_zero_tracker
+net_zero_tracker:SB:2025,SB,Relative emission reduction,2025.0,2025,27.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Solomon%20Islands%20First/NDC%20Report%202021%20Final%20Solomon%20Islands%20(1).pdf,net_zero_tracker
+net_zero_tracker:SE:2030,SE,Absolute emission reduction,1990.0,2030,63.0,percent,https://www.government.se/495f60/contentassets/883ae8e123bc4e42aa8d59296ebe0478/the-swedish-climate-policy-framework.pdf,net_zero_tracker
+net_zero_tracker:SI:2030,SI,Absolute emission reduction,2005.0,2030,36.0,percent,https://unfccc.int/sites/default/files/resource/LTS1_SLOVENIA_EN.pdf,net_zero_tracker
+net_zero_tracker:SK:2030,SK,Absolute emission reduction,1990.0,2030,40.0,percent,https://unfccc.int/sites/default/files/resource/LTS%20SK%20eng.pdf,net_zero_tracker
+net_zero_tracker:SO:2030,SO,Relative emission reduction,2030.0,2030,30.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Somalia%20First/Final%20Updated%20NDC%20for%20Somalia%202021.pdf,net_zero_tracker
+net_zero_tracker:ST:2030,ST,Relative emission reduction,2030.0,2030,27.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:TD:2030,TD,Absolute emission reduction,2018.0,2030,19.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:TG:2030,TG,Absolute emission reduction,2010.0,2030,20.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:TH:2030,TH,Relative emission reduction,2030.0,2030,30.0,percent,https://unfccc.int/sites/default/files/NDC/2022-11/Thailand%202nd%20Updated%20NDC.pdf,net_zero_tracker
+net_zero_tracker:TR:2030,TR,Relative emission reduction,2030.0,2030,21.0,percent,https://www2.tbmm.gov.tr/d27/2/2-3853.pdf,net_zero_tracker
+net_zero_tracker:TT:2030,TT,Relative emission reduction,2030.0,2030,15.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:TV:2025,TV,Absolute emission reduction,2010.0,2025,60.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:UA:2030,UA,Absolute emission reduction,1990.0,2030,65.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Ukraine%20First/Ukraine%20NDC_July%2031.pdf,net_zero_tracker
+net_zero_tracker:US:2030,US,Absolute emission reduction,2005.0,2030,52.0,percent,https://www.whitehouse.gov/wp-content/uploads/2021/10/US-Long-Term-Strategy.pdf,net_zero_tracker
+net_zero_tracker:VN:2030,VN,Relative emission reduction,2030.0,2030,15.0,percent,https://unfccc.int/sites/default/files/NDC/2022-11/Viet%20Nam%20NDC%202022%20Update.pdf,net_zero_tracker
+net_zero_tracker:WS:2030,WS,Absolute emission reduction,2007.0,2030,26.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:YE:2030,YE,Absolute emission reduction,2020.0,2030,14.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:ZM:2030,ZM,Relative emission reduction,2030.0,2030,25.0,percent,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:CA-BC:2050,CA-BC,Absolute emission reduction,2007.0,2050,80.0,percent,https://www2.gov.bc.ca/gov/content/environment/climate-change,net_zero_tracker
+net_zero_tracker:CA-NL:2050,CA-NL,Absolute emission reduction,1990.0,2050,85.0,percent,https://www.gov.nl.ca/releases/2020/mae/0605n04/,net_zero_tracker
+net_zero_tracker:CA-ON:2030,CA-ON,Absolute emission reduction,2005.0,2030,30.0,percent,https://prod-environmental-registry.s3.amazonaws.com/2018-11/EnvironmentPlan.pdf,net_zero_tracker
+net_zero_tracker:DE-HB:2020,DE-HB,Absolute emission reduction,1990.0,2020,40.0,percent,https://www.bauumwelt.bremen.de/klimaschutz/klima-energie/klimaschutz-in-bremen-24312,net_zero_tracker
+net_zero_tracker:DE-HH:2050,DE-HH,Absolute emission reduction,1990.0,2050,95.0,percent,https://www.landesrecht-hamburg.de/bsha/document/jlr-KlimaSchGHA2020pP4,net_zero_tracker
+net_zero_tracker:ES-AR:2030,ES-AR,Absolute emission reduction,1990.0,2030,40.0,percent,https://www.aragon.es/documents/20127/674325/ESTRATEGIA_ARAGONESA_CAMBIO_CLIMATICO.pdf/f4206c8d-94e0-acdd-9fb3-2e69f9d9b7dd,net_zero_tracker
+net_zero_tracker:ES-CM:2030,ES-CM,Absolute emission reduction,2005.0,2030,26.0,percent,https://www.castillalamancha.es/gobierno/desarrollosostenible/estructura/dgecocir/actuaciones/estrategia-de-cambio-clim%C3%A1tico-de-castilla-la-mancha-2020-2030,net_zero_tracker
+net_zero_tracker:ES-MC:2030,ES-MC,Absolute emission reduction,2016.0,2030,40.0,percent,https://www.murcia.es/medio-ambiente/medio-ambiente/material/estrategia_cambio_climatico/Estrategia_ONLINE%20cambio%20climatico.pdf,net_zero_tracker
+net_zero_tracker:ES-MD:2030,ES-MD,Absolute emission reduction,1990.0,2030,40.0,percent,https://www.madrid.es/UnidadesDescentralizadas/Sostenibilidad/CalidadAire/Ficheros/PlanAire&CC_Eng.pdf,net_zero_tracker
+net_zero_tracker:ES-NA:2050,ES-NA,Absolute emission reduction,2005.0,2050,80.0,percent,https://lifenadapta.navarra.es/documents/2696321/2696934/GN_KLINA_Res_ing_rev_190122.pdf/62f9da85-be55-a740-e428-98039e634210?t=1582010696850,net_zero_tracker
+net_zero_tracker:ES-NC:2050,ES-NC,Absolute emission reduction,2005.0,2050,80.0,percent,https://lifenadapta.navarra.es/documents/2696321/2696934/LIFE+NAdapta_+Hoja+de+Ruta+KLINA.pdf/26ff0133-329b-d42b-fb56-290f1d3362fd?t=1557401328262,net_zero_tracker
+net_zero_tracker:ES-PV:2050,ES-PV,Absolute emission reduction,1990.0,2050,80.0,percent,https://www.theclimategroup.org/states-and-regions-under2-coalition,net_zero_tracker
+net_zero_tracker:FR-NOR:2030,FR-NOR,Absolute emission reduction,2015.0,2030,50.0,percent,https://terrifica.eu/wp-content/uploads/2019/09/TeRRIFICA_FRANCE_state_of_art_OnlinePublication.pdf,net_zero_tracker
+net_zero_tracker:FR-PDL:2030,FR-PDL,Absolute emission reduction,2015.0,2030,50.0,percent,https://terrifica.eu/wp-content/uploads/2019/09/TeRRIFICA_FRANCE_state_of_art_OnlinePublication.pdf,net_zero_tracker
+net_zero_tracker:MX-BCN:2030,MX-BCN,Absolute emission reduction,2021.0,2030,25.0,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Under2%20Coalition%20Baja-California%20Appendix.pdf,net_zero_tracker
+net_zero_tracker:MX-CAM:2050,MX-CAM,Absolute emission reduction,1990.0,2050,80.0,percent,https://www.theclimategroup.org/sites/default/files/2020-10/apendice_campeche.pdf,net_zero_tracker
+net_zero_tracker:MX-COL:2050,MX-COL,Absolute emission reduction,2010.0,2050,50.0,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Colima-Appendix-English.pdf,net_zero_tracker
+net_zero_tracker:MX-NLE:2050,MX-NLE,Absolute emission reduction,1990.0,2050,95.0,percent,https://www.theclimategroup.org/sites/default/files/2020-10/nuevo_leon_apendice.pdf,net_zero_tracker
+net_zero_tracker:MX-OAX:2050,MX-OAX,Relative emission reduction,2013.0,2050,58.0,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Under2MOU%20Ap%C3%A9ndice%20Oaxaca.pdf,net_zero_tracker
+net_zero_tracker:MX-ROO:2050,MX-ROO,Absolute emission reduction,2016.0,2050,63.0,percent,https://www.theclimategroup.org/sites/default/files/2021-10/Quintana%20Roo%20Pathway%20Executive%20Summary.pdf,net_zero_tracker
+net_zero_tracker:MX-SON:2050,MX-SON,Absolute emission reduction,2010.0,2050,95.0,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Under2%20Coalition%20Sonora%20Appendix.pdf,net_zero_tracker
+net_zero_tracker:MX-YUC:2030,MX-YUC,Relative emission reduction,2005.0,2030,40.0,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Yucatan-appendix.pdf,net_zero_tracker
+net_zero_tracker:MY-04:2030,MY-04,Absolute emission reduction,2015.0,2030,45.0,percent,https://www.academia.edu/41117425/MELAKA_STATE_CLIMATE_ACTION_PLAN_2020_2030_Prepared_by,net_zero_tracker
+net_zero_tracker:US-CO:2050,US-CO,Absolute emission reduction,2005.0,2050,90.0,percent,https://leg.colorado.gov/bills/hb19-1261,net_zero_tracker
+net_zero_tracker:US-CT:2050,US-CT,Absolute emission reduction,1990.0,2050,80.0,percent,https://portal.ct.gov/-/media/DEEP/climatechange/publications/BuildingaLowCarbonFutureforCTGC3Recommendationspdf.pdf,net_zero_tracker
+net_zero_tracker:US-DE:2030,US-DE,Absolute emission reduction,2008.0,2030,30.0,percent,https://documents.dnrec.delaware.gov/energy/Documents/2016%20Climate%20Action%20Progress%20Report/Climate%20Action%20in%20Delaware%202016%20Progress%20Report.pdf,net_zero_tracker
+net_zero_tracker:US-FL:2050,US-FL,Absolute emission reduction,1990.0,2050,80.0,percent,https://www.fsec.ucf.edu/en/media/enews/2007/pdf/07-127-emissions.pdf,net_zero_tracker
+net_zero_tracker:US-GA:2030,US-GA,Absolute emission reduction,1990.0,2030,35.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Georgia%20First/NDC%20Georgia_ENG%20WEB-approved.pdf,net_zero_tracker
+net_zero_tracker:US-MN:2050,US-MN,Absolute emission reduction,2005.0,2050,80.0,percent,https://climate.state.mn.us/,net_zero_tracker
+net_zero_tracker:US-NH:2050,US-NH,Absolute emission reduction,2001.0,2050,80.0,percent,,net_zero_tracker
+net_zero_tracker:US-OR:2050,US-OR,Absolute emission reduction,1990.0,2050,80.0,percent,https://www.oregon.gov/gov/Documents/executive_orders/eo_20-04.pdf,net_zero_tracker
+net_zero_tracker:US-PA:2050,US-PA,Absolute emission reduction,2005.0,2050,80.0,percent,https://www.dep.pa.gov/Citizens/climate/Pages/PA-Climate-Action-Plan.aspx,net_zero_tracker
+net_zero_tracker:US-RI:2050,US-RI,Absolute emission reduction,1990.0,2050,80.0,percent,http://climatechange.ri.gov/state-actions/governor-climate-priorities.php,net_zero_tracker
+net_zero_tracker:US-UT:2050,US-UT,Absolute emission reduction,2005.0,2050,80.0,percent,https://gardner.utah.edu/utahroadmap/,net_zero_tracker
+net_zero_tracker:US-VT:2050,US-VT,Absolute emission reduction,1990.0,2050,80.0,percent,http://climatechange.ri.gov/state-actions/governor-climate-priorities.php,net_zero_tracker
+net_zero_tracker:ZA-GP:2030,ZA-GP,Absolute emission reduction,2010.0,2030,66.0,percent,https://amcham.co.za/wp-content/uploads/2020/12/Gauteng-City-Region-Over-arching-Climate-Change-Response-Strategy-and-Action-Plan-March-2020-Final.pdf,net_zero_tracker
+net_zero_tracker:AU-ACT:2025,AU-ACT,Absolute emission reduction,1990.0,2025,60.0,percent,"https://www.environment.act.gov.au/__data/assets/pdf_file/0003/1414641/ACT-Climate-Change-Strategy-2019-2025.pdf/_recache#:~:text=The%20Australian%20Capital%20Territory%20(ACT,reduction%20in%20emissions%20by%202020.",net_zero_tracker
+net_zero_tracker:AU-NSW:2030,AU-NSW,Absolute emission reduction,2005.0,2030,50.0,percent,https://www.energy.nsw.gov.au/nsw-plans-and-progress/government-strategies-and-frameworks/reaching-net-zero-emissions,net_zero_tracker
+net_zero_tracker:AU-QLD:2030,AU-QLD,Absolute emission reduction,2005.0,2030,30.0,percent,https://www.qld.gov.au/__data/assets/pdf_file/0026/67283/qld-climate-transition-strategy.pdf,net_zero_tracker
+net_zero_tracker:AU-SA:2030,AU-SA,Absolute emission reduction,2005.0,2030,50.0,percent,https://www.environment.sa.gov.au/topics/climate-change/government-action-on-climate-change,net_zero_tracker
+net_zero_tracker:AU-VIC:2035,AU-VIC,Absolute emission reduction,2005.0,2035,75.0,percent,https://www.danandrews.com.au/news/putting-power-back-in-the-hands-of-victorians,net_zero_tracker
+net_zero_tracker:CA-BC:2040,CA-BC,Absolute emission reduction,2007.0,2040,60.0,percent,https://www2.gov.bc.ca/gov/content/environment/climate-change,net_zero_tracker
+net_zero_tracker:CA-MB:2030,CA-MB,Absolute emission reduction,2005.0,2030,33.0,percent,https://www.gov.mb.ca/sd/annual-reports/sdif/mb-climate-change-green-economy-action-plan.pdf,net_zero_tracker
+net_zero_tracker:CA-NL:2020,CA-NL,Absolute emission reduction,1990.0,2020,10.0,percent,https://www.gov.nl.ca/releases/2020/mae/0605n04/,net_zero_tracker
+net_zero_tracker:CA-NS:2030,CA-NS,Absolute emission reduction,1990.0,2030,53.0,percent,https://nslegislature.ca/legc/bills/63rd_2nd/3rd_read/b213.htm,net_zero_tracker
+net_zero_tracker:CA-NT:2030,CA-NT,Absolute emission reduction,2005.0,2030,50.0,percent,https://www.ntassembly.ca/sites/assembly/files/td_103-192.pdf,net_zero_tracker
+net_zero_tracker:CA-PE:2030,CA-PE,Absolute emission reduction,2005.0,2030,30.0,percent,https://www.princeedwardisland.ca/sites/default/files/publications/pei_path_towards_net_zero_framework.pdf,net_zero_tracker
+net_zero_tracker:CA-QC:2030,CA-QC,Absolute emission reduction,1990.0,2030,37.0,percent,https://www.quebec.ca/en/government/policies-orientations/plan-green-economy,net_zero_tracker
+net_zero_tracker:CA-YT:2030,CA-YT,Absolute emission reduction,2010.0,2030,30.0,percent,https://yukon.ca/sites/yukon.ca/files/env/env-our-clean-future.pdf,net_zero_tracker
+net_zero_tracker:DE-BE:2030,DE-BE,Absolute emission reduction,1990.0,2030,70.0,percent,https://gesetze.berlin.de/bsbe/document/jlr-EWendGBErahmen,net_zero_tracker
+net_zero_tracker:DE-BW:2030,DE-BW,Absolute emission reduction,1990.0,2030,25.0,percent,https://um.baden-wuerttemberg.de/fileadmin/redaktion/m-um/intern/Dateien/Dokumente/4_Klima/Klimaschutz/Klimaschutzgesetz/Klimaschutzgesetz-Baden-Wuerttemberg-englische-Fassung-Januar-2021.pdf,net_zero_tracker
+net_zero_tracker:DE-BY:2030,DE-BY,Absolute emission reduction,1990.0,2030,55.0,percent,https://www.gesetze-bayern.de/Content/Document/BayKlimaG,net_zero_tracker
+net_zero_tracker:DE-HH:2030,DE-HH,Absolute emission reduction,1990.0,2030,55.0,percent,https://www.landesrecht-hamburg.de/bsha/document/jlr-KlimaSchGHA2020pP4,net_zero_tracker
+net_zero_tracker:DE-NW:2030,DE-NW,Absolute emission reduction,1990.0,2030,65.0,percent,https://www.klimaschutz.nrw.de/instrumente/klimaschutzgesetz,net_zero_tracker
+net_zero_tracker:DE-RP:2020,DE-RP,Absolute emission reduction,1990.0,2020,40.0,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Rhineland-Palatinate-Appendix-English.pdf,net_zero_tracker
+net_zero_tracker:DE-TH:2030,DE-TH,Absolute emission reduction,1990.0,2030,70.0,percent,https://www.swsz.de/die-swsz/medien-center/veroeffentlichungspflichten/thuerklimag,net_zero_tracker
+net_zero_tracker:ES-CN:2030,ES-CN,Absolute emission reduction,2010.0,2030,37.0,percent,https://www3.gobiernodecanarias.org/ceic/energia/oecan/files/20220214_Estrategia_Sostenible_Canarias_docCompleto_01.pdf,net_zero_tracker
+net_zero_tracker:ES-CT:2030,ES-CT,Absolute emission reduction,1990.0,2030,40.0,percent,https://canviclimatic.gencat.cat/ca/ambits/Llei_canvi_climatic/,net_zero_tracker
+net_zero_tracker:ES-MC:2020,ES-MC,Absolute emission reduction,2008.0,2020,20.0,percent,https://www.murcia.es/medio-ambiente/medio-ambiente/material/estrategia_cambio_climatico/Estrategia_ONLINE%20cambio%20climatico.pdf,net_zero_tracker
+net_zero_tracker:ES-MD:2020,ES-MD,Absolute emission reduction,2010.0,2020,36.0,percent,https://www.madrid.es/UnidadesDescentralizadas/Sostenibilidad/CalidadAire/Ficheros/PlanAire&CC_Eng.pdf,net_zero_tracker
+net_zero_tracker:ES-NA:2030,ES-NA,Absolute emission reduction,2005.0,2030,45.0,percent,https://lifenadapta.navarra.es/documents/2696321/2696934/GN_KLINA_Res_ing_rev_190122.pdf/62f9da85-be55-a740-e428-98039e634210?t=1582010696850,net_zero_tracker
+net_zero_tracker:ES-NC:2030,ES-NC,Absolute emission reduction,2005.0,2030,45.0,percent,https://lifenadapta.navarra.es/documents/2696321/2696934/LIFE+NAdapta_+Hoja+de+Ruta+KLINA.pdf/26ff0133-329b-d42b-fb56-290f1d3362fd?t=1557401328262,net_zero_tracker
+net_zero_tracker:ES-PV:2030,ES-PV,Absolute emission reduction,2005.0,2030,40.0,percent,https://www.theclimategroup.org/states-and-regions-under2-coalition,net_zero_tracker
+net_zero_tracker:FR-ARA:2030,FR-ARA,Absolute emission reduction,2015.0,2030,30.0,percent,https://www.auvergnerhonealpes-ee.fr/qui-sommes-nous/lagence-en-bref,net_zero_tracker
+net_zero_tracker:FR-NOR:2020,FR-NOR,Absolute emission reduction,2015.0,2020,30.0,percent,https://terrifica.eu/wp-content/uploads/2019/09/TeRRIFICA_FRANCE_state_of_art_OnlinePublication.pdf,net_zero_tracker
+net_zero_tracker:FR-PDL:2020,FR-PDL,Absolute emission reduction,2015.0,2020,30.0,percent,https://terrifica.eu/wp-content/uploads/2019/09/TeRRIFICA_FRANCE_state_of_art_OnlinePublication.pdf,net_zero_tracker
+net_zero_tracker:GB-ENG:2030,GB-ENG,Absolute emission reduction,1990.0,2030,68.0,percent,https://www.gov.uk/government/news/uk-enshrines-new-target-in-law-to-slash-emissions-by-78-by-2035,net_zero_tracker
+net_zero_tracker:GB-NIR:2030,GB-NIR,Absolute emission reduction,1990.0,2030,48.0,percent,http://www.niassembly.gov.uk/globalassets/documents/legislation/bills/executive-bills/session-2017-2022/climate-change-no.-2-bill/climate-chnage-no.-2-bill-as-amended-at-fcs---full-print-version.pdf,net_zero_tracker
+net_zero_tracker:GB-SCT:2030,GB-SCT,Absolute emission reduction,1990.0,2030,75.0,percent,https://www.legislation.gov.uk/asp/2019/15/contents/enacted,net_zero_tracker
+net_zero_tracker:GB-WLS:2030,GB-WLS,Absolute emission reduction,1990.0,2030,63.0,percent,https://gov.wales/sites/default/files/publications/2021-10/net-zero-wales-summary-document.pdf,net_zero_tracker
+net_zero_tracker:JP-01:2030,JP-01,Absolute emission reduction,2013.0,2030,31.0,percent,https://www.pref.aomori.lg.jp/soshiki/kankyo/kankyo/2050CO2zero.html,net_zero_tracker
+net_zero_tracker:JP-01:2030,JP-01,Absolute emission reduction,2013.0,2030,35.0,percent,https://www.pref.hokkaido.lg.jp/ks/tot/ontaikeikakukaitei.html,net_zero_tracker
+net_zero_tracker:JP-03:2030,JP-03,Absolute emission reduction,2013.0,2030,32.0,percent,https://www.pref.iwate.jp/kurashikankyou/kankyou/seisaku/1005573.html,net_zero_tracker
+net_zero_tracker:JP-04:2030,JP-04,Absolute emission reduction,2013.0,2030,31.0,percent,https://www.env.go.jp/policy/zerocarbon.html,net_zero_tracker
+net_zero_tracker:JP-06:2030,JP-06,Absolute emission reduction,2013.0,2030,26.0,percent,https://www.pref.yamagata.jp/050015/kurashi/kankyo/management/plan/4thplan.html,net_zero_tracker
+net_zero_tracker:JP-07:2030,JP-07,Absolute emission reduction,2013.0,2030,45.0,percent,https://www.pref.fukushima.lg.jp/sec/16035a/carbon-neutral.html,net_zero_tracker
+net_zero_tracker:JP-09:2030,JP-09,Absolute emission reduction,2013.0,2030,26.0,percent,https://www.pref.tochigi.lg.jp/d02/eco/kankyou/ondanka/documents/kikoukeikaku.pdf,net_zero_tracker
+net_zero_tracker:JP-10:2030,JP-10,Absolute emission reduction,2013.0,2030,50.0,percent,https://www.pref.gunma.jp/04/cp01_00022.html,net_zero_tracker
+net_zero_tracker:JP-12:2030,JP-12,Absolute emission reduction,2013.0,2030,22.0,percent,https://www.pref.chiba.lg.jp/shigen/chikyuukankyou/zerosengen.html,net_zero_tracker
+net_zero_tracker:JP-13:2030,JP-13,Absolute emission reduction,2000.0,2030,30.0,percent,https://www.kankyo.metro.tokyo.lg.jp/policy_others/zeroemission_tokyo/strategy_2020update.html,net_zero_tracker
+net_zero_tracker:JP-14:2030,JP-14,Absolute emission reduction,2013.0,2030,27.0,percent,https://www.pref.kanagawa.jp/documents/59045/datsutanso.pdf,net_zero_tracker
+net_zero_tracker:JP-15:2030,JP-15,Absolute emission reduction,2013.0,2030,26.0,percent,https://www.pref.niigata.lg.jp/site/kankyo/1239566486047.html,net_zero_tracker
+net_zero_tracker:JP-16:2030,JP-16,Absolute emission reduction,2013.0,2030,30.0,percent,https://www.pref.toyama.jp/100223/kurashi/kankyoushizen/kankyou/kj00021656.html,net_zero_tracker
+net_zero_tracker:JP-18:2030,JP-18,Absolute emission reduction,2013.0,2030,28.0,percent,https://www.pref.fukui.lg.jp/doc/kankyou/2050-co2-0.html,net_zero_tracker
+net_zero_tracker:JP-19:2030,JP-19,Absolute emission reduction,2013.0,2030,26.0,percent,https://www.pref.yamanashi.jp/kankyo-ene/stopondankayamanashikaigi.html,net_zero_tracker
+net_zero_tracker:JP-20:2030,JP-20,Absolute emission reduction,2010.0,2030,60.0,percent,https://www.pref.nagano.lg.jp/kankyo/keikaku/zerocarbon/index.html,net_zero_tracker
+net_zero_tracker:JP-21:2030,JP-21,Absolute emission reduction,2013.0,2030,33.0,percent,https://www.pref.gifu.lg.jp/page/8674.html,net_zero_tracker
+net_zero_tracker:JP-22:2021,JP-22,Absolute emission reduction,2005.0,2021,21.0,percent,https://www.pref.shizuoka.jp/kankyou/ka-030/earth/carbon-neutral.html,net_zero_tracker
+net_zero_tracker:JP-24:2030,JP-24,Absolute emission reduction,2013.0,2030,30.0,percent,https://www.pref.mie.lg.jp/common/01/ci500015424.htm,net_zero_tracker
+net_zero_tracker:JP-25:2030,JP-25,Absolute emission reduction,2013.0,2030,23.0,percent,https://www.pref.shiga.lg.jp/ippan/kankyoshizen/ondanka/309038.html,net_zero_tracker
+net_zero_tracker:JP-26:2030,JP-26,Absolute emission reduction,2013.0,2030,40.0,percent,https://www.pref.kyoto.jp/tikyu/suishinkeikaku.html,net_zero_tracker
+net_zero_tracker:JP-27:2030,JP-27,Absolute emission reduction,2013.0,2030,33.0,percent,https://www.kankyo.pref.hyogo.lg.jp/application/files/7016/1578/8440/b99e09762bd46d7c8ff9c64976693843.pdf,net_zero_tracker
+net_zero_tracker:JP-27:2030,JP-27,Absolute emission reduction,2013.0,2030,40.0,percent,https://www.pref.osaka.lg.jp/chikyukankyo/jigyotoppage/27_3keikaku.html,net_zero_tracker
+net_zero_tracker:JP-29:2030,JP-29,Absolute emission reduction,2013.0,2030,45.0,percent,http://www.eco.pref.nara.jp/jorei_kisoku/sogo_keikaku.html,net_zero_tracker
+net_zero_tracker:JP-30:2030,JP-30,Absolute emission reduction,2013.0,2030,30.0,percent,https://www.pref.wakayama.lg.jp/prefg/032000/envplan/index.html,net_zero_tracker
+net_zero_tracker:JP-31:2030,JP-31,Absolute emission reduction,2013.0,2030,40.0,percent,https://www.pref.tottori.lg.jp/initiative_plan/,net_zero_tracker
+net_zero_tracker:JP-32:2030,JP-32,Absolute emission reduction,2013.0,2030,21.0,percent,https://www.pref.shimane.lg.jp/infra/kankyo/kankyo/kankyo_sougou/sougoukeikaku.html,net_zero_tracker
+net_zero_tracker:JP-33:2030,JP-33,Absolute emission reduction,2013.0,2030,17.0,percent,https://www.env.go.jp/policy/zerocarbon.html,net_zero_tracker
+net_zero_tracker:JP-34:2030,JP-34,Absolute emission reduction,2013.0,2030,50.0,percent,https://www.pref.tokushima.lg.jp/ippannokata/kurashi/shizen/5035820,net_zero_tracker
+net_zero_tracker:JP-34:2030,JP-34,Absolute emission reduction,2013.0,2030,22.0,percent,https://www.pref.hiroshima.lg.jp/site/eco/b-b12-plan22-keikaku.html,net_zero_tracker
+net_zero_tracker:JP-35:2030,JP-35,Absolute emission reduction,2013.0,2030,27.0,percent,https://www.pref.ehime.jp/kankyou/k-hp/theme/ondanka/keikaku.html,net_zero_tracker
+net_zero_tracker:JP-36:2030,JP-36,Absolute emission reduction,2013.0,2030,27.0,percent,https://www.pref.saga.lg.jp/kiji00379726/index.html,net_zero_tracker
+net_zero_tracker:JP-37:2030,JP-37,Absolute emission reduction,2013.0,2030,31.0,percent,https://www.pref.nagasaki.jp/bunrui/kurashi-kankyo/kankyohozen-ondankataisaku/ondanka/ondanka-actionplan-dai2ji/,net_zero_tracker
+net_zero_tracker:JP-38:2030,JP-38,Absolute emission reduction,2013.0,2030,50.0,percent,https://www.pref.kumamoto.jp/soshiki/49/103587.html,net_zero_tracker
+net_zero_tracker:JP-39:2030,JP-39,Absolute emission reduction,2013.0,2030,33.0,percent,http://www.pref.kagoshima.jp/kawara/documents/89273_20210802111303-1.pdf,net_zero_tracker
+net_zero_tracker:JP-39:2030,JP-39,Absolute emission reduction,2013.0,2030,29.0,percent,https://www.pref.kochi.lg.jp/soshiki/030901/2021032500328.html,net_zero_tracker
+net_zero_tracker:JP-41:2030,JP-41,Absolute emission reduction,2013.0,2030,35.0,percent,https://www.pref.oita.jp/soshiki/13060/dai5kikeikaku.html,net_zero_tracker
+net_zero_tracker:JP-45:2030,JP-45,Absolute emission reduction,2013.0,2030,26.0,percent,http://www.pref.miyazaki.lg.jp/kankyoshinrin/kense/kekaku/20210303113521.html,net_zero_tracker
+net_zero_tracker:JP-47:2030,JP-47,Absolute emission reduction,2013.0,2030,26.0,percent,https://www.pref.okinawa.jp/site/kankyo/saisei/jikkkou-keikaku.html,net_zero_tracker
+net_zero_tracker:KR-49:2030,KR-49,Absolute emission reduction,2017.0,2030,33.0,percent,https://www.investkorea.org/jj-en/bbs/i-1536/detail.do?ntt_sn=2,net_zero_tracker
+net_zero_tracker:MX-BCN:2021,MX-BCN,Absolute emission reduction,2020.0,2021,15.0,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Under2%20Coalition%20Baja-California%20Appendix.pdf,net_zero_tracker
+net_zero_tracker:MX-COL:2030,MX-COL,Absolute emission reduction,2010.0,2030,30.0,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Colima-Appendix-English.pdf,net_zero_tracker
+net_zero_tracker:MX-JAL:2030,MX-JAL,Absolute emission reduction,2010.0,2030,45.0,percent,https://app.semadet.jalisco.gob.mx/cs/EECC_15042021.pdf,net_zero_tracker
+net_zero_tracker:MX-NLE:2030,MX-NLE,Absolute emission reduction,1990.0,2030,45.0,percent,https://www.theclimategroup.org/sites/default/files/2020-10/nuevo_leon_apendice.pdf,net_zero_tracker
+net_zero_tracker:MX-ROO:2030,MX-ROO,Absolute emission reduction,2016.0,2030,21.0,percent,https://www.theclimategroup.org/sites/default/files/2021-10/Quintana%20Roo%20Pathway%20Executive%20Summary.pdf,net_zero_tracker
+net_zero_tracker:MX-SON:2030,MX-SON,Absolute emission reduction,2010.0,2030,25.0,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Under2%20Coalition%20Sonora%20Appendix.pdf,net_zero_tracker
+net_zero_tracker:MX-YUC:2018,MX-YUC,Relative emission reduction,2005.0,2018,20.0,percent,https://www.theclimategroup.org/sites/default/files/2020-10/Yucatan-appendix.pdf,net_zero_tracker
+net_zero_tracker:MY-04:2025,MY-04,Absolute emission reduction,2015.0,2025,30.0,percent,https://www.academia.edu/41117425/MELAKA_STATE_CLIMATE_ACTION_PLAN_2020_2030_Prepared_by,net_zero_tracker
+net_zero_tracker:US-CA:2030,US-CA,Absolute emission reduction,1990.0,2030,40.0,percent,https://www.ca.gov/archive/gov39/wp-content/uploads/2018/09/9.10.18-Executive-Order.pdf,net_zero_tracker
+net_zero_tracker:US-CO:2025,US-CO,Absolute emission reduction,2005.0,2025,26.0,percent,https://leg.colorado.gov/bills/hb19-1261,net_zero_tracker
+net_zero_tracker:US-CT:2030,US-CT,Absolute emission reduction,1990.0,2030,45.0,percent,https://portal.ct.gov/-/media/DEEP/climatechange/publications/BuildingaLowCarbonFutureforCTGC3Recommendationspdf.pdf,net_zero_tracker
+net_zero_tracker:US-DE:2025,US-DE,Absolute emission reduction,2005.0,2025,26.0,percent,https://documents.dnrec.delaware.gov/energy/Documents/2016%20Climate%20Action%20Progress%20Report/Climate%20Action%20in%20Delaware%202016%20Progress%20Report.pdf,net_zero_tracker
+net_zero_tracker:US-HI:2020,US-HI,Absolute emission reduction,1990.0,2020,19.0,percent,https://www.capitol.hawaii.gov/session2018/bills/HB2182_CD1_.htm,net_zero_tracker
+net_zero_tracker:US-IL:2025,US-IL,Absolute emission reduction,2005.0,2025,26.0,percent,https://www.illinois.gov/government/executive-orders/executive-order.executive-order-number-6.2019.html,net_zero_tracker
+net_zero_tracker:US-LA:2025,US-LA,Absolute emission reduction,2005.0,2025,26.0,percent,https://gov.louisiana.gov/assets/ExecutiveOrders/2020/JBE-2020-18-Climate-Initiatives-Task-Force.pdf,net_zero_tracker
+net_zero_tracker:US-MA:2030,US-MA,Absolute emission reduction,1990.0,2030,45.0,percent,https://malegislature.gov/Laws/SessionLaws/Acts/2021/Chapter8,net_zero_tracker
+net_zero_tracker:US-MD:2031,US-MD,Absolute emission reduction,2006.0,2031,60.0,percent,https://mgaleg.maryland.gov/2022RS/fnotes/bil_0008/sb0528.pdf,net_zero_tracker
+net_zero_tracker:US-ME:2030,US-ME,Absolute emission reduction,1990.0,2030,45.0,percent,https://www.maine.gov/governor/mills/sites/maine.gov.governor.mills/files/inline-files/Executive%20Order%209-23-2019_0.pdf,net_zero_tracker
+net_zero_tracker:US-MI:2025,US-MI,Absolute emission reduction,2005.0,2025,28.0,percent,https://www.michigan.gov/documents/egle/Draft-MI-Healthy-Climate-Plan_745872_7.pdf,net_zero_tracker
+net_zero_tracker:US-MN:2025,US-MN,Absolute emission reduction,2005.0,2025,30.0,percent,https://climate.state.mn.us/,net_zero_tracker
+net_zero_tracker:US-NH:2020,US-NH,Absolute emission reduction,1990.0,2020,10.0,percent,,net_zero_tracker
+net_zero_tracker:US-NV:2025,US-NV,Absolute emission reduction,2005.0,2025,28.0,percent,https://www.leg.state.nv.us/App/NELIS/REL/80th2019/Bill/6431/Text,net_zero_tracker
+net_zero_tracker:US-NY:2030,US-NY,Absolute emission reduction,1990.0,2030,40.0,percent,https://www.nysenate.gov/legislation/bills/2019/s6599,net_zero_tracker
+net_zero_tracker:US-OR:2035,US-OR,Absolute emission reduction,1990.0,2035,45.0,percent,https://www.oregon.gov/gov/Documents/executive_orders/eo_20-04.pdf,net_zero_tracker
+net_zero_tracker:US-PA:2025,US-PA,Absolute emission reduction,2005.0,2025,26.0,percent,https://www.dep.pa.gov/Citizens/climate/Pages/PA-Climate-Action-Plan.aspx,net_zero_tracker
+net_zero_tracker:US-UT:2025,US-UT,Absolute emission reduction,2005.0,2025,25.0,percent,https://gardner.utah.edu/utahroadmap/,net_zero_tracker
+net_zero_tracker:US-VT:2025,US-VT,Absolute emission reduction,2005.0,2025,26.0,percent,http://climatechange.ri.gov/state-actions/governor-climate-priorities.php,net_zero_tracker
+net_zero_tracker:US-WA:2030,US-WA,Absolute emission reduction,1990.0,2030,45.0,percent,https://ecology.wa.gov/Air-Climate/Climate-change/Greenhouse-gases,net_zero_tracker
+net_zero_tracker:ZA-GP:2020,ZA-GP,Absolute emission reduction,2010.0,2020,21.0,percent,https://amcham.co.za/wp-content/uploads/2020/12/Gauteng-City-Region-Over-arching-Climate-Change-Response-Strategy-and-Action-Plan-March-2020-Final.pdf,net_zero_tracker
+net_zero_tracker:ZA-KZN:2030,ZA-KZN,Absolute emission reduction,2015.0,2030,40.0,percent,"https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5c8ab5851647e100801756a3/5e5e3f71469c8b00a735fbac/files/Climate_Action_Plan_web.pdf?1583234929#:~:text=A%201.5%C2%B0C%20CAP,increase%20to%201.5%C2%B0C.",net_zero_tracker
+net_zero_tracker:BG SOF:2030,BG SOF,Absolute emission reduction,2007.0,2030,40.0,percent,https://www.ebrdgreencities.com/assets/Uploads/PDF/7181e1a1c8/Sofia-GCAP_ENG.pdf,net_zero_tracker
+net_zero_tracker:BR CPS:2060,BR CPS,Absolute emission reduction,2016.0,2060,32.0,percent,https://bibliotecajuridica.campinas.sp.gov.br/index/visualizaroriginal/id/136363,net_zero_tracker
+net_zero_tracker:CA CAL:2050,CA CAL,Absolute emission reduction,2005.0,2050,80.0,percent,https://www.calgary.ca/content/dam/www/uep/esm/documents/esm-documents/climate-resilience-strategy-and-action-plans-annual-report-2020.pdf,net_zero_tracker
+net_zero_tracker:CA OTT:2050,CA OTT,Absolute emission reduction,2012.0,2050,100.0,percent,https://documents.ottawa.ca/sites/documents/files/climate_change_mplan_en.pdf,net_zero_tracker
+net_zero_tracker:CA WNP:2050,CA WNP,Absolute emission reduction,2011.0,2050,80.0,percent,https://winnipeg.ca/sustainability/PublicEngagement/ClimateActionPlan/pdfs/CW_Climate-Action-Plan.pdf,net_zero_tracker
+net_zero_tracker:CN SGH:2035,CN SGH,Absolute emission reduction,2025.0,2035,5.0,percent,https://fgw.sh.gov.cn/zgjjl/20210701/23960c2ed0b543aa9d253604989bfdab.html,net_zero_tracker
+net_zero_tracker:CO CTG:2050,CO CTG,Absolute emission reduction,2008.0,2050,40.0,percent,https://plan4c.cartagena.gov.co/wp-content/uploads/2018/06/20150428171251_PLAN-DE-ADAPTACION-4C_ingles-1.pdf,net_zero_tracker
+net_zero_tracker:DE FRA:2050,DE FRA,Absolute emission reduction,1990.0,2050,95.0,percent,https://frankfurt.de/themen/klima-und-energie,net_zero_tracker
+net_zero_tracker:DE HAJ:2035,DE HAJ,Absolute emission reduction,1990.0,2035,95.0,percent,https://www.hannover.de/content/download/575256/file/23352_B_100%20Prozent%20Klimaschutz-engl-WEB.pdf,net_zero_tracker
+net_zero_tracker:ES ZAZ:2030,ES ZAZ,Absolute emission reduction,2005.0,2030,55.0,percent,http://www.zaragoza.es/contenidos/medioambiente/2021-PACES-Zaragoza-2030.pdf,net_zero_tracker
+net_zero_tracker:GE TBS:2030,GE TBS,Absolute emission reduction,1990.0,2030,39.0,percent,https://hexagonagility.com/story/how-tbilisi-is-improving-human-health-and-driving-its-transit-fleet-into-the-future/,net_zero_tracker
+net_zero_tracker:GR SKG:2030,GR SKG,Absolute emission reduction,2011.0,2030,40.0,percent,https://resilientcitiesnetwork.org/downloadable_resources/Network/Thessaloniki-Resilience-Strategy-English.pdf,net_zero_tracker
+net_zero_tracker:HR ZAG:2030,HR ZAG,Absolute emission reduction,2008.0,2030,40.0,percent,https://balkangreenenergynews.com/zagreb-adopts-first-sustainable-energy-and-climate-action-plan-in-croatia/,net_zero_tracker
+net_zero_tracker:IE DUB:2030,IE DUB,Absolute emission reduction,2006.0,2030,40.0,percent,https://www.dublincity.ie/residential/environment/dublin-city-councils-climate-change-action-plan-2019-2024/dublin-city-council-climate-action-plan-2019-2024,net_zero_tracker
+net_zero_tracker:IT BLQ:2030,IT BLQ,Absolute emission reduction,2005.0,2030,40.0,percent,https://iclei-europe.org/member-in-the-spotlight/previous/bologna-italy/,net_zero_tracker
+net_zero_tracker:IT CTA:2030,IT CTA,Absolute emission reduction,2011.0,2030,40.0,percent,https://www.comune.catania.it/informazioni/cstampa/default.aspx?cs=32678,net_zero_tracker
+net_zero_tracker:IT GOA:2030,IT GOA,Absolute emission reduction,2005.0,2030,40.0,percent,,net_zero_tracker
+net_zero_tracker:IT PMO:2050,IT PMO,Absolute emission reduction,1990.0,2050,30.0,percent,,net_zero_tracker
+net_zero_tracker:IT VRN:2030,IT VRN,Absolute emission reduction,2006.0,2030,40.0,percent,,net_zero_tracker
+net_zero_tracker:JP NGO:2050,JP NGO,Absolute emission reduction,1990.0,2050,80.0,percent,https://www.city.nagoya.jp/kankyo/page/0000103019.html,net_zero_tracker
+net_zero_tracker:MX LEN:2030,MX LEN,Absolute emission reduction,2017.0,2030,58.0,percent,https://leon.gob.mx/modulos/img/adjuntos/adjuntos-646.pdf,net_zero_tracker
+net_zero_tracker:PT OPO:2030,PT OPO,Absolute emission reduction,2004.0,2030,50.0,percent,https://www.themayor.eu/en/a/view/porto-s-path-towards-cutting-greenhouse-gas-emission-5216,net_zero_tracker
+net_zero_tracker:SE GOT:2050,SE GOT,Absolute emission reduction,1990.0,2050,80.0,percent,https://carbonn.org/uploads/tx_carbonndata/Climate%20Programme_%20Folder.pdf,net_zero_tracker
+net_zero_tracker:TW KHH:2050,TW KHH,Absolute emission reduction,2005.0,2050,80.0,percent,https://www.climate-chance.org/wp-content/uploads/2020/04/synthesis-report-2019-local-action-book-case-kaohsiung_korea-p74.pdf,net_zero_tracker
+net_zero_tracker:US BNA:2050,US BNA,Absolute emission reduction,2014.0,2050,80.0,percent,https://www.nashville.gov/departments/mayor/news/mayor-cooper-announces-multiple-initiatives-combat-climate-change-and-promote,net_zero_tracker
+net_zero_tracker:US CHI:2040,US CHI,Absolute emission reduction,2017.0,2040,62.0,percent,https://www.chicago.gov/content/dam/city/sites/climate-action-plan/documents/CHICAGO_CAP_20220429.pdf,net_zero_tracker
+net_zero_tracker:US CLE:2050,US CLE,Absolute emission reduction,2010.0,2050,80.0,percent,https://drive.google.com/file/d/1Z3234sMp7S7MjaXvMgcZtcAaYs4x2oHE/view,net_zero_tracker
+net_zero_tracker:US CON:2050,US CON,Absolute emission reduction,2008.0,2050,80.0,percent,https://concordma.gov/DocumentCenter/View/25318/Sustainable-Concord-Climate-Action-and-Resilience-Plan-2020?bidId=,net_zero_tracker
+net_zero_tracker:US COS:2050,US COS,Absolute emission reduction,2005.0,2050,90.0,percent,https://leg.colorado.gov/sites/default/files/2021a_1266_signed.pdf,net_zero_tracker
+net_zero_tracker:US CVG:2050,US CVG,Absolute emission reduction,2006.0,2050,84.0,percent,https://www.cincinnati-oh.gov/sites/oes/assets/File/2018%20Green%20Cincinnati%20Plan(1).pdf,net_zero_tracker
+net_zero_tracker:US FAT:2050,US FAT,Absolute emission reduction,1990.0,2050,80.0,percent,https://www.fresno.gov/darm/wp-content/uploads/sites/10/2020/03/Appendix_G-GHG_Reduction_Plan_Update.pdf,net_zero_tracker
+net_zero_tracker:US LUI:2050,US LUI,Absolute emission reduction,2016.0,2050,80.0,percent,https://louisvilleky.gov/sustainability/document/ghgerpfinaldraft202004220pdf,net_zero_tracker
+net_zero_tracker:US MEM:2050,US MEM,Absolute emission reduction,2016.0,2050,71.0,percent,https://shelbycountytn.gov/DocumentCenter/View/37431/Memphis-Area-Climate-Action-Plan-2019-FINAL_4_JANUARY-2020,net_zero_tracker
+net_zero_tracker:US MES:2050,US MES,Absolute emission reduction,2006.0,2050,80.0,percent,https://www2.minneapolismn.gov/government/programs-initiatives/climate/climate-action-goals/greenhouse-gas-emissions-reductions/,net_zero_tracker
+net_zero_tracker:US ORL:2040,US ORL,Absolute emission reduction,2007.0,2040,90.0,percent,https://www.orlando.gov/files/sharedassets/public/departments/sustainability/2018_orlando_communityactionplan.pdf,net_zero_tracker
+net_zero_tracker:US PDX:2050,US PDX,Absolute emission reduction,1990.0,2050,80.0,percent,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5ab410faa2f42204838f7990/5ad0e40c74c4837def5d292e/files/CAP-2015_june30-2015_web.pdf?1565172676,net_zero_tracker
+net_zero_tracker:US PIT:2050,US PIT,Absolute emission reduction,2003.0,2050,80.0,percent,https://apps.pittsburghpa.gov/redtail/images/7101_Pittsburgh_Climate_Action_Plan_3.0.pdf,net_zero_tracker
+net_zero_tracker:US ROC:2030,US ROC,Absolute emission reduction,2010.0,2030,40.0,percent,https://www.cityofrochester.gov/climateactionplan/,net_zero_tracker
+net_zero_tracker:US SJC:2050,US SJC,Absolute emission reduction,1990.0,2050,80.0,percent,https://www.sanjoseca.gov/your-government/department-directory/planning-building-code-enforcement/planning-division/environmental-planning/greenhouse-gas-reduction-strategy,net_zero_tracker
+net_zero_tracker:AR BUE:2030,AR BUE,Absolute emission reduction,2015.0,2030,52.0,percent,https://www.buenosaires.gob.ar/sites/gcaba/files/pac_resumen_ejecutivo_esp_0.pdf,net_zero_tracker
+net_zero_tracker:AU MEL:2025,AU MEL,Absolute emission reduction,2015.0,2025,10.0,percent,https://www.melbourne.vic.gov.au/sitecollectiondocuments/climate-change-mitigation-strategy-2050.pdf,net_zero_tracker
+net_zero_tracker:BG SOF:2020,BG SOF,Absolute emission reduction,2007.0,2020,22.0,percent,https://www.ebrdgreencities.com/assets/Uploads/PDF/7181e1a1c8/Sofia-GCAP_ENG.pdf,net_zero_tracker
+net_zero_tracker:BR BHZ:2030,BR BHZ,Absolute emission reduction,2007.0,2030,20.0,percent,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:BR CPS:2025,BR CPS,Absolute emission reduction,2016.0,2025,5.0,percent,https://bibliotecajuridica.campinas.sp.gov.br/index/visualizaroriginal/id/136363,net_zero_tracker
+net_zero_tracker:BR FOR:2030,BR FOR,Absolute emission reduction,2014.0,2030,30.0,percent,https://americadosul.iclei.org/wp-content/uploads/sites/78/2021/07/30-plac-fortaleza-final-ingles.pdf,net_zero_tracker
+net_zero_tracker:BR REC:2030,BR REC,Absolute emission reduction,2017.0,2030,30.0,percent,https://americadosul.iclei.org/wp-content/uploads/sites/78/2021/07/30-plac-recife-final-ingles.pdf,net_zero_tracker
+net_zero_tracker:BR RIO:2030,BR RIO,Absolute emission reduction,2017.0,2030,20.0,percent,https://www.citiesoftomorrow.eu/sites/default/files/documents/Executive_Summary_finalok.pdf,net_zero_tracker
+net_zero_tracker:BR SAO:2020,BR SAO,Absolute emission reduction,2005.0,2020,20.0,percent,https://smastr16.blob.core.windows.net/home/2021/10/cop26_english.pdf,net_zero_tracker
+net_zero_tracker:BR SSA:2024,BR SSA,Absolute emission reduction,2018.0,2024,15.0,percent,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5c8ab5851647e100801756a3/60abe3e2795a8b00a674dd75/files/PMAMC_Ebook_ingles.pdf?1621877739,net_zero_tracker
+net_zero_tracker:CA CAL:2030,CA CAL,Absolute emission reduction,2005.0,2030,40.0,percent,https://www.calgary.ca/content/dam/www/uep/esm/documents/esm-documents/climate-resilience-strategy-and-action-plans-annual-report-2020.pdf,net_zero_tracker
+net_zero_tracker:CA OTT:2025,CA OTT,Absolute emission reduction,2012.0,2025,43.0,percent,https://documents.ottawa.ca/sites/documents/files/climate_change_mplan_en.pdf,net_zero_tracker
+net_zero_tracker:CA WNP:2030,CA WNP,Absolute emission reduction,2011.0,2030,20.0,percent,https://winnipeg.ca/sustainability/PublicEngagement/ClimateActionPlan/pdfs/CW_Climate-Action-Plan.pdf,net_zero_tracker
+net_zero_tracker:CO BOG:2030,CO BOG,Relative emission reduction,2030.0,2030,50.0,percent,https://climateaction.unfccc.int/views/stakeholder-details.html?id=11180,net_zero_tracker
+net_zero_tracker:CZ PRG:2030,CZ PRG,Absolute emission reduction,2010.0,2030,45.0,percent,https://klima.praha.eu/DATA/Dokumenty/Klimaplan_2109_15_online_LOWRES_final2.pdf,net_zero_tracker
+net_zero_tracker:DE BER:2030,DE BER,Absolute emission reduction,1990.0,2030,70.0,percent,https://gesetze.berlin.de/bsbe/document/jlr-EWendGBErahmen,net_zero_tracker
+net_zero_tracker:DE EEN:2030,DE EEN,Absolute emission reduction,1990.0,2030,60.0,percent,"https://www.essen.de/leben/umwelt/luft/treibhausgas_bilanz.de.html#:~:text=August%202020%20per%20Ratsbeschluss%20nachgesch%C3%A4rft,2040%20um%2085%20%25%20gegen%C3%BCber%201990.",net_zero_tracker
+net_zero_tracker:DE ESS:2030,DE ESS,Absolute emission reduction,1990.0,2030,60.0,percent,"https://www.essen.de/leben/umwelt/luft/treibhausgas_bilanz.de.html#:~:text=August%202020%20per%20Ratsbeschluss%20nachgesch%C3%A4rft,2040%20um%2085%20%25%20gegen%C3%BCber%201990.",net_zero_tracker
+net_zero_tracker:DE HAM:2030,DE HAM,Absolute emission reduction,1990.0,2030,70.0,percent,https://www.hamburg.de/contentblob/13899086/749a6e50662c96eee81d370f1b0cb631/data/d-first-revision-hamburg-climate-plan.pdf,net_zero_tracker
+net_zero_tracker:DE ONU:2030,DE ONU,Absolute emission reduction,1990.0,2030,60.0,percent,"https://www.essen.de/leben/umwelt/luft/treibhausgas_bilanz.de.html#:~:text=August%202020%20per%20Ratsbeschluss%20nachgesch%C3%A4rft,2040%20um%2085%20%25%20gegen%C3%BCber%201990.",net_zero_tracker
+net_zero_tracker:DE STR:2030,DE STR,Absolute emission reduction,2019.0,2030,65.0,percent,https://www.stuttgart.de/leben/umwelt/energie/,net_zero_tracker
+net_zero_tracker:EC UIO:2030,EC UIO,Absolute emission reduction,2030.0,2030,43.0,percent,http://www.quitoambiente.gob.ec/images/Secretaria_Ambiente/Cambio_Climatico/plan_accion_climatico_quito_2020/Folleto%20Resumen%20PACQ01_mar_21.pdf,net_zero_tracker
+net_zero_tracker:ES BCN:2030,ES BCN,Absolute emission reduction,2005.0,2030,45.0,percent,https://www.barcelona.cat/barcelona-pel-clima/sites/default/files/documents/climate_plan_maig.pdf,net_zero_tracker
+net_zero_tracker:ES MAD:2030,ES MAD,Absolute emission reduction,1990.0,2030,65.0,percent,https://www.madrid.es/UnidadesDescentralizadas/Sostenibilidad/EspeInf/EnergiayCC/06Divulgaci%C3%B3n/6cDocumentacion/6cNHRNeutral/Ficheros/RoadmapENG.pdf,net_zero_tracker
+net_zero_tracker:ES VLC:2030,ES VLC,Absolute emission reduction,2007.0,2030,40.0,percent,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:ET ADD:2030,ET ADD,Relative emission reduction,2030.0,2030,41.0,percent,https://addisenviroment.gov.et/wp-content/uploads/2021/10/C-40-September-14-compressed.pdf,net_zero_tracker
+net_zero_tracker:FR BOD:2020,FR BOD,Absolute emission reduction,2007.0,2020,25.0,percent,https://en.calameo.com/read/0014801211e68b0f697d0,net_zero_tracker
+net_zero_tracker:FR GNB:2030,FR GNB,Absolute emission reduction,2005.0,2030,50.0,percent,https://www.grenoblealpesmetropole.fr/cms_viewFile.php?idtf=7126&path=Strategie-et-plan-d-actions.pdf,net_zero_tracker
+net_zero_tracker:FR NTE:2030,FR NTE,Absolute emission reduction,2003.0,2030,50.0,percent,https://metropole.nantes.fr/territoire-institutions/projet/ambitions-territoire/33-engagements-pour-la-transitio,net_zero_tracker
+net_zero_tracker:FR PAR:2030,FR PAR,Absolute emission reduction,2004.0,2030,50.0,percent,"https://www.c40knowledgehub.org/s/article/Paris-Climate-Action-Plan-Towards-a-carbon-neutral-city-and-100-renewable-energy?language=en_US#:~:text=By%202030%2C%20an%20operational%20action,100%25%20reliant%20on%20renewable%20energy.",net_zero_tracker
+net_zero_tracker:GB GLW:2020,GB GLW,Absolute emission reduction,2006.0,2020,30.0,percent,https://www.glasgow.gov.uk/CHttpHandler.ashx?id=50623&p=0,net_zero_tracker
+net_zero_tracker:GB MNC:2025,GB MNC,Absolute emission reduction,2020.0,2025,50.0,percent,https://www.manchesterclimate.com/sites/default/files/Manchester%20Climate%20Change%20Framework%202020-25.pdf,net_zero_tracker
+net_zero_tracker:GH ACC:2030,GH ACC,Absolute emission reduction,2020.0,2030,50.0,percent,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5ab410faa2f42204838f7990/5ab5605ea2f4220acf45cfa6/files/Accra_Climate_Action_Plan.pdf?1603293785,net_zero_tracker
+net_zero_tracker:GR SKG:2020,GR SKG,Absolute emission reduction,2011.0,2020,20.0,percent,https://resilientcitiesnetwork.org/downloadable_resources/Network/Thessaloniki-Resilience-Strategy-English.pdf,net_zero_tracker
+net_zero_tracker:HK HKG:2035,HK HKG,Absolute emission reduction,2005.0,2035,50.0,percent,https://www.climateready.gov.hk/files/pdf/CAP2050_booklet_en.pdf,net_zero_tracker
+net_zero_tracker:HR ZAG:2020,HR ZAG,Absolute emission reduction,2008.0,2020,21.0,percent,https://balkangreenenergynews.com/zagreb-adopts-first-sustainable-energy-and-climate-action-plan-in-croatia/,net_zero_tracker
+net_zero_tracker:HU BUD:2030,HU BUD,Absolute emission reduction,2015.0,2030,40.0,percent,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:IT BLQ:2020,IT BLQ,Absolute emission reduction,2005.0,2020,21.0,percent,https://iclei-europe.org/member-in-the-spotlight/previous/bologna-italy/,net_zero_tracker
+net_zero_tracker:IT CTA:2020,IT CTA,Absolute emission reduction,2011.0,2020,22.0,percent,https://www.comune.catania.it/informazioni/cstampa/default.aspx?cs=32678,net_zero_tracker
+net_zero_tracker:IT GOA:2020,IT GOA,Absolute emission reduction,2005.0,2020,23.0,percent,,net_zero_tracker
+net_zero_tracker:IT PMO:2020,IT PMO,Absolute emission reduction,1990.0,2020,22.0,percent,,net_zero_tracker
+net_zero_tracker:IT VRN:2020,IT VRN,Absolute emission reduction,2006.0,2020,20.0,percent,,net_zero_tracker
+net_zero_tracker:JO AMM:2030,JO AMM,Absolute emission reduction,2014.0,2030,40.0,percent,https://www.amman.jo/site_doc/climate.pdf,net_zero_tracker
+net_zero_tracker:JP HMM:2030,JP HMM,Absolute emission reduction,2013.0,2030,30.0,percent,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:JP KKJ:2030,JP KKJ,Absolute emission reduction,2013.0,2030,30.0,percent,https://www.city.kitakyushu.lg.jp/kankyou/00200196.html,net_zero_tracker
+net_zero_tracker:JP KWS:2030,JP KWS,Absolute emission reduction,2013.0,2030,20.0,percent,https://www.city.kawasaki.jp/300/page/0000121670.html,net_zero_tracker
+net_zero_tracker:JP MYJ:2030,JP MYJ,Absolute emission reduction,2013.0,2030,27.0,percent,https://www.city.matsuyama.ehime.jp/shisei/machizukuri/kankyoumodel/modelkeikaku.html,net_zero_tracker
+net_zero_tracker:JP NGO:2030,JP NGO,Absolute emission reduction,2013.0,2030,27.0,percent,https://www.city.nagoya.jp/kankyo/page/0000103019.html,net_zero_tracker
+net_zero_tracker:JP SAK:2030,JP SAK,Absolute emission reduction,2013.0,2030,27.0,percent,https://www.city.sakai.lg.jp/shisei/gyosei/shishin/kankyo/torikumi/env_strat.html,net_zero_tracker
+net_zero_tracker:JP SGH:2030,JP SGH,Absolute emission reduction,2013.0,2030,46.0,percent,https://www.city.sagamihara.kanagawa.jp/kurashi/kankyo/plan/1023953/index.html,net_zero_tracker
+net_zero_tracker:JP SPK:2030,JP SPK,Absolute emission reduction,2016.0,2030,55.0,percent,https://www.city.sapporo.jp/kankyo/ondanka/kikouhendou_plan2020/index.html,net_zero_tracker
+net_zero_tracker:JP UKB:2030,JP UKB,Absolute emission reduction,2013.0,2030,34.0,percent,https://www.city.kobe.lg.jp/documents/4411/20201209_2050zero.pdf,net_zero_tracker
+net_zero_tracker:JP YOK:2030,JP YOK,Absolute emission reduction,2014.0,2030,30.0,percent,https://www.city.yokohama.lg.jp/kurashi/machizukuri-kankyo/ondanka/jikkou/,net_zero_tracker
+net_zero_tracker:KE NBO:2035,KE NBO,Relative emission reduction,2035.0,2035,44.0,percent,https://cdn.nation.co.ke/downloads/Nairobi-City-Climate-Action-2021.pdf,net_zero_tracker
+net_zero_tracker:KR SEL:2030,KR SEL,Absolute emission reduction,2005.0,2030,40.0,percent,https://www.si.re.kr/si_download/63602/27895,net_zero_tracker
+net_zero_tracker:LV RIX:2020,LV RIX,Absolute emission reduction,1990.0,2020,55.0,percent,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:MX GDL:2030,MX GDL,Absolute emission reduction,2017.0,2030,40.0,percent,https://transparencia.info.jalisco.gob.mx/sites/default/files/Plan%20de%20acci%C3%B3n%20clim%C3%A1tica.pdf,net_zero_tracker
+net_zero_tracker:MY KUL:2030,MY KUL,Relative emission reduction,2030.0,2030,40.0,percent,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5ab410faa2f42204838f7990/5b4e04e374782004ac0c8ac2/files/C40_KLCAP2050_viewing-only-MR-single.pdf?1626096224,net_zero_tracker
+net_zero_tracker:NG ABV:2030,NG ABV,Absolute emission reduction,2030.0,2030,20.0,percent,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Nigeria%20First/NIGERIA%202021%20NDC-FINAL.pdf,net_zero_tracker
+net_zero_tracker:NG LOS:2035,NG LOS,Absolute emission reduction,2020.0,2035,45.0,percent,https://moelagos.gov.ng/wp-content/uploads/2021/09/C40-Lagos_Indesign-Document-Full-Report-Revert-2_Update-2.pdf,net_zero_tracker
+net_zero_tracker:NL AMS:2030,NL AMS,Absolute emission reduction,1990.0,2030,55.0,percent,https://www.amsterdam.nl/en/policy/sustainability/policy-climate-neutrality/,net_zero_tracker
+net_zero_tracker:NL RTM:2030,NL RTM,Absolute emission reduction,1990.0,2030,49.0,percent,https://www.010duurzamestad.nl/wat-wij-doen/Rotterdamse-klimaataanpak-mei-2019.pdf,net_zero_tracker
+net_zero_tracker:NO OSL:2023,NO OSL,Absolute emission reduction,2009.0,2023,52.0,percent,https://tinyurl.com/2kxrny69,net_zero_tracker
+net_zero_tracker:NZ AKL:2030,NZ AKL,Absolute emission reduction,2016.0,2030,50.0,percent,https://www.aucklandcouncil.govt.nz/plans-projects-policies-reports-bylaws/our-plans-strategies/topic-based-plans-strategies/environmental-plans-strategies/aucklands-climate-plan/Documents/auckland-climate-plan.pdf,net_zero_tracker
+net_zero_tracker:PT OPO:2020,PT OPO,Absolute emission reduction,2004.0,2020,45.0,percent,https://www.themayor.eu/en/a/view/porto-s-path-towards-cutting-greenhouse-gas-emission-5216,net_zero_tracker
+net_zero_tracker:SN DKR:2030,SN DKR,Relative emission reduction,2030.0,2030,25.0,percent,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5c8ab5851647e100801756a3/60dadeb05761d600a57c9345/files/C40_Dakar_English_Final.pdf?1624956592,net_zero_tracker
+net_zero_tracker:TR AYT:2030,TR AYT,Absolute emission reduction,2019.0,2030,40.0,percent,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:TR IST:2030,TR IST,Relative emission reduction,2030.0,2030,33.0,percent,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:TR IZM:2030,TR IZM,Absolute emission reduction,2018.0,2030,40.0,percent,,net_zero_tracker
+net_zero_tracker:TW KHH:2030,TW KHH,Absolute emission reduction,2005.0,2030,50.0,percent,https://www.climate-chance.org/wp-content/uploads/2020/04/synthesis-report-2019-local-action-book-case-kaohsiung_korea-p74.pdf,net_zero_tracker
+net_zero_tracker:TW TNN:2030,TW TNN,Absolute emission reduction,2005.0,2030,20.0,percent,https://www.tainan.gov.tw/en/News_Content.aspx?n=13205&sms=13686&s=7768548,net_zero_tracker
+net_zero_tracker:TZ DAR:2030,TZ DAR,Relative emission reduction,2030.0,2030,29.0,percent,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5c8ab5851647e100801756a3/623af4b0bf8bcc8b7c5a7d76/files/Dar_CAP_English_Version_Final_16_Dec_2021.pdf?1648030896,net_zero_tracker
+net_zero_tracker:US BNA:2030,US BNA,Absolute emission reduction,2014.0,2030,40.0,percent,https://www.nashville.gov/departments/mayor/news/mayor-cooper-announces-multiple-initiatives-combat-climate-change-and-promote,net_zero_tracker
+net_zero_tracker:US CLE:2030,US CLE,Absolute emission reduction,2010.0,2030,40.0,percent,https://drive.google.com/file/d/1Z3234sMp7S7MjaXvMgcZtcAaYs4x2oHE/view,net_zero_tracker
+net_zero_tracker:US CON:2030,US CON,Absolute emission reduction,2008.0,2030,45.0,percent,https://concordma.gov/DocumentCenter/View/25318/Sustainable-Concord-Climate-Action-and-Resilience-Plan-2020?bidId=,net_zero_tracker
+net_zero_tracker:US COS:2025,US COS,Absolute emission reduction,2005.0,2025,26.0,percent,https://leg.colorado.gov/sites/default/files/2021a_1266_signed.pdf,net_zero_tracker
+net_zero_tracker:US CVG:2028,US CVG,Absolute emission reduction,2006.0,2028,40.0,percent,https://www.cincinnati-oh.gov/sites/oes/assets/File/2018%20Green%20Cincinnati%20Plan(1).pdf,net_zero_tracker
+net_zero_tracker:US FAT:2030,US FAT,Absolute emission reduction,1990.0,2030,40.0,percent,https://www.fresno.gov/darm/wp-content/uploads/sites/10/2020/03/Appendix_G-GHG_Reduction_Plan_Update.pdf,net_zero_tracker
+net_zero_tracker:US MEM:2035,US MEM,Absolute emission reduction,2016.0,2035,51.0,percent,https://shelbycountytn.gov/DocumentCenter/View/37431/Memphis-Area-Climate-Action-Plan-2019-FINAL_4_JANUARY-2020,net_zero_tracker
+net_zero_tracker:US MES:2025,US MES,Absolute emission reduction,2006.0,2025,30.0,percent,https://www2.minneapolismn.gov/government/programs-initiatives/climate/climate-action-goals/greenhouse-gas-emissions-reductions/,net_zero_tracker
+net_zero_tracker:US PDX:2030,US PDX,Absolute emission reduction,1990.0,2030,40.0,percent,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5ab410faa2f42204838f7990/5ad0e40c74c4837def5d292e/files/CAP-2015_june30-2015_web.pdf?1565172676,net_zero_tracker
+net_zero_tracker:US PIT:2023,US PIT,Absolute emission reduction,2003.0,2023,20.0,percent,https://apps.pittsburghpa.gov/redtail/images/7101_Pittsburgh_Climate_Action_Plan_3.0.pdf,net_zero_tracker
+net_zero_tracker:US ROC:2020,US ROC,Absolute emission reduction,2010.0,2020,20.0,percent,https://www.cityofrochester.gov/climateactionplan/,net_zero_tracker
+net_zero_tracker:US SJC:2030,US SJC,Absolute emission reduction,1990.0,2030,36.0,percent,https://www.sanjoseca.gov/your-government/department-directory/planning-building-code-enforcement/planning-division/environmental-planning/greenhouse-gas-reduction-strategy,net_zero_tracker
+net_zero_tracker:VN HAN:2030,VN HAN,Absolute emission reduction,2020.0,2030,15.0,percent,https://en.vietnamplus.vn/hanoi-aims-to-reduce-greenhouse-gas-emissions/191063.vnp,net_zero_tracker
+net_zero_tracker:ZA DUR:2030,ZA DUR,Absolute emission reduction,2015.0,2030,40.0,percent,https://tinyurl.com/2zdlc28c,net_zero_tracker
+net_zero_tracker:ZA JNB:2030,ZA JNB,Absolute emission reduction,2016.0,2030,25.0,percent,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5ab410faa2f42204838f7990/5ab5614aa2f4220acf45cfb8/files/City_of_Johannesburg_-_CAP-lores-compressed.pdf?1623066563,net_zero_tracker
+net_zero_tracker:ZA PRY:2030,ZA PRY,Absolute emission reduction,2015.0,2030,15.0,percent,https://www.tshwane.gov.za/sites/Council/Ofiice-Of-The-Executive-Mayor/Climate%20Action/CAP_EXECUTIVE%20SUMMARY%20REPORT%20no%20marks.pdf,net_zero_tracker
+net_zero_tracker:1FRVQX2CRLGC1XLP5727:2025,1FRVQX2CRLGC1XLP5727,Relative emission reduction,2019.0,2025,50.0,percent,https://www.marathonoil.com/sustainability/environment/climate-change/,net_zero_tracker
+net_zero_tracker:2138007JNS19JHNA2336:2030,2138007JNS19JHNA2336,Absolute emission reduction,2014.0,2030,55.0,percent,https://www.sgs.com/en/news/2018/04/sgs-becomes-one-of-100-companies-to-commit-to-science-based-targets-for-greenhouse-gas-emissions,net_zero_tracker
+net_zero_tracker:2138008J191VLSGY5A09:2030,2138008J191VLSGY5A09,Absolute emission reduction,2015.0,2030,38.0,percent,https://ucb-s3-storage.s3.eu-central-1.amazonaws.com/2021_UCB_Integrated_Annual_Report_ENG_86e2c54bdc.pdf,net_zero_tracker
+net_zero_tracker:213800M993ICXOMBCP87:2020,213800M993ICXOMBCP87,Absolute emission reduction,2016.0,2020,50.0,percent,https://www.sjp.co.uk/~/media/Files/S/SJP-Corp/document-library/reports/2021/SJP_CDP-Report_April2021.pdf,net_zero_tracker
+net_zero_tracker:353800D83H0V3ZV1SV24:2050,353800D83H0V3ZV1SV24,Absolute emission reduction,2010.0,2050,90.0,percent,https://www.globalsuzuki.com/corporate/csr_environment/intro/vision.html,net_zero_tracker
+net_zero_tracker:353800H2UB5ZEZRZQC02:2030,353800H2UB5ZEZRZQC02,Absolute emission reduction,2014.0,2030,40.0,percent,https://www.mitsubishi-motors.com/en/sustainability/pdf/report-2020/sustainability2020_e.pdf?201214,net_zero_tracker
+net_zero_tracker:353800JX1R4582QVK932:2050,353800JX1R4582QVK932,Absolute emission reduction,2018.0,2050,80.0,percent,https://www.terumo.com/sustainability/reports/pdf/SustainabilityDataBook_2020_E.pdf,net_zero_tracker
+net_zero_tracker:353800K1RXV3E3JAE812:2050,353800K1RXV3E3JAE812,Absolute emission reduction,2010.0,2050,90.0,percent,https://www.mazda.com/en/csr/environment/sustainable/,net_zero_tracker
+net_zero_tracker:353800KOFMRGOXSJ5Z65:2050,353800KOFMRGOXSJ5Z65,Absolute emission reduction,2017.0,2050,87.0,percent,https://www.mec.co.jp/e/sustainability/activities/environment/climate-change/,net_zero_tracker
+net_zero_tracker:353800UT0TLROREPIC92:2030,353800UT0TLROREPIC92,Absolute emission reduction,2018.0,2030,50.0,percent,https://www.ajinomoto.com/sustainability/materiality/climate_change.php,net_zero_tracker
+net_zero_tracker:353800XGIU2IHQGC9504:2030,353800XGIU2IHQGC9504,Absolute emission reduction,2015.0,2030,37.0,percent,https://www.daiichisankyo.com/our_stories/detail/index_4090.html,net_zero_tracker
+net_zero_tracker:3BNYRYQHD39K4LCKQF12:2030,3BNYRYQHD39K4LCKQF12,Relative emission reduction,2014.0,2030,30.0,percent,https://www.marathonpetroleum.com/Sustainability/Lowering-Carbon-Intensity/,net_zero_tracker
+net_zero_tracker:3PPKBHUG1HD6BO7RNR87:2050,3PPKBHUG1HD6BO7RNR87,Absolute emission reduction,2005.0,2050,50.0,percent,https://www.textron.com/assets/CR/2019/ProductSustainabilityHighlights.html,net_zero_tracker
+net_zero_tracker:41BNNE1AFPNAZELZ6K07:2030,41BNNE1AFPNAZELZ6K07,Absolute emission reduction,2019.0,2030,50.0,percent,https://publish-p33711-e119406.adobeaemcloud.com/content/dam/site/company/csr/doc/2019_Sustainability_F.pdf.coredownload.inline.pdf,net_zero_tracker
+net_zero_tracker:529900FNDVTQJOVVPZ19:2030,529900FNDVTQJOVVPZ19,Absolute emission reduction,2020.0,2030,40.0,percent,https://www.thalesgroup.com/fr/group/journaliste/press-release/thales-comment-hautes-technologies-peuvent-reduire-court-terme,net_zero_tracker
+net_zero_tracker:529900YT4O5S0LCXWD54:2050,529900YT4O5S0LCXWD54,Absolute emission reduction,2013.0,2050,85.0,percent,https://www.obayashi.co.jp/en/sustainability/environment/tcfd.html,net_zero_tracker
+net_zero_tracker:5493000CGCQY2OQU7669:2030,5493000CGCQY2OQU7669,Absolute emission reduction,2019.0,2030,50.0,percent,https://www.jabil.com/about-us/sustainability/our-operations-and-resources.html,net_zero_tracker
+net_zero_tracker:5493007JDSMX8Z5Z1902:2030,5493007JDSMX8Z5Z1902,Absolute emission reduction,2020.0,2030,42.0,percent,https://www.campbellsoupcompany.com/newsroom/news/reducing-greenhouse-gas-emissions-in-our-operations/,net_zero_tracker
+net_zero_tracker:5493008C12PZMWP3WY03:2034,5493008C12PZMWP3WY03,Absolute emission reduction,2019.0,2034,42.0,percent,https://www.kcsouthern.com/corporate-responsibility/our-commitment/KCS-2019-Sustainability-Report.pdf,net_zero_tracker
+net_zero_tracker:5493008FFSI8SQ74AT93:2050,5493008FFSI8SQ74AT93,Absolute emission reduction,2013.0,2050,80.0,percent,https://global.kawasaki.com/en/corp/sustainability/environment/20_houkokusyo.pdf,net_zero_tracker
+net_zero_tracker:549300CSY4INHEHQQT13:2030,549300CSY4INHEHQQT13,Absolute emission reduction,2014.0,2030,30.0,percent,https://www.kubota.com/sustainability/environment/ghg/index.html,net_zero_tracker
+net_zero_tracker:549300D8GOWWH0SJB189:2030,549300D8GOWWH0SJB189,Absolute emission reduction,2005.0,2030,90.0,percent,https://www.nisource.com/docs/librariesprovider2/sustainability-archives/2021/2021-cdp-climate-change-response.pdf?sfvrsn=4,net_zero_tracker
+net_zero_tracker:549300H5LSF8DP3RIJ34:2031,549300H5LSF8DP3RIJ34,Relative emission reduction,2018.0,2031,30.0,percent,https://www.tel.com/csr/environment/,net_zero_tracker
+net_zero_tracker:549300QD81EPLH4NUQ92:2040,549300QD81EPLH4NUQ92,Absolute emission reduction,2015.0,2040,90.0,percent,https://www.results.philips.com/publications/ar20,net_zero_tracker
+net_zero_tracker:549300QQXOOYEF89IC56:2030,549300QQXOOYEF89IC56,Absolute emission reduction,2020.0,2030,42.0,percent,https://www.responsibilityreports.com/HostedData/ResponsibilityReports/PDF/NASDAQ_WDC_2021.pdf,net_zero_tracker
+net_zero_tracker:549300RPTUOIXG4LIH86:2030,549300RPTUOIXG4LIH86,Absolute emission reduction,2011.0,2030,30.0,percent,https://www.walgreensbootsalliance.com/sites/www/files/2021-01/WBA_CDP_Climate_Change_Questionnaire_2020_26%20Aug.pdf,net_zero_tracker
+net_zero_tracker:549300XTO5VR8SKV1V74:2035,549300XTO5VR8SKV1V74,Absolute emission reduction,2011.0,2035,100.0,percent,https://www.valero.com/sites/default/files/valero-documents/2020%20SRR_Web%20Version_Spreads%207-26.pdf,net_zero_tracker
+net_zero_tracker:5T547R1474YC9HOD8Q74:2025,5T547R1474YC9HOD8Q74,Absolute emission reduction,2016.0,2025,35.0,percent,https://www.waters.com/webassets/cms/category/docs/Sustainability_Report_2020.pdf,net_zero_tracker
+net_zero_tracker:6EY4K7ZMF9UX1CU6KC79:2030,6EY4K7ZMF9UX1CU6KC79,Absolute emission reduction,2015.0,2030,50.0,percent,https://www.xilinx.com/content/dam/xilinx/publications/about/xilinx-cdp-climate-change-2021.pdf,net_zero_tracker
+net_zero_tracker:787RXPR0UX0O0XUXPZ81:2030,787RXPR0UX0O0XUXPZ81,Absolute emission reduction,2021.0,2030,65.0,percent,https://news.nike.com/news/our-carbon-footprint-and-our-next-steps,net_zero_tracker
+net_zero_tracker:894500ZRIX9K13RHXR17:2030,894500ZRIX9K13RHXR17,Absolute emission reduction,2019.0,2030,35.0,percent,https://www.te.com/usa-en/about-te/corporate-responsibility.html,net_zero_tracker
+net_zero_tracker:8MYN82XMYQH89CTMTH67:2030,8MYN82XMYQH89CTMTH67,Absolute emission reduction,2019.0,2030,46.0,percent,https://www.anthemcorporateresponsibility.com/environmental-policy-and-commitments,net_zero_tracker
+net_zero_tracker:CZ72ZHBVKZXQRV3XFE26:2025,CZ72ZHBVKZXQRV3XFE26,Relative emission reduction,2019.0,2025,33.0,percent,https://sustainability.ovintiv.com/environment/emissions-and-climate-change/,net_zero_tracker
+net_zero_tracker:CZ72ZHBVKZXQRV3XFE26:2030,CZ72ZHBVKZXQRV3XFE26,Absolute emission reduction,2017.0,2030,30.0,percent,https://www.otsuka.com/en/csr/environment/climate.html,net_zero_tracker
+net_zero_tracker:D3W7PCXCBRQLL17DZ313:2050,D3W7PCXCBRQLL17DZ313,Absolute emission reduction,2005.0,2050,50.0,percent,https://www.wfscorp.com/en/wfscorp/docs/WFS-2019-Sustainability-Report.pdf,net_zero_tracker
+net_zero_tracker:DYTQ8KRTKO7Y2BVU5K74:2030,DYTQ8KRTKO7Y2BVU5K74,Absolute emission reduction,2018.0,2030,30.0,percent,https://www.keurigdrpepper.com/content/dam/keurig-brand-sites/kdp/files/KDP-CR-Report-2021.pdf,net_zero_tracker
+net_zero_tracker:FR5LCKFTG8054YNNRU85:2035,FR5LCKFTG8054YNNRU85,Absolute emission reduction,2015.0,2035,50.0,percent,https://www.abbvie.com/content/dam/abbvie-dotcom/uploads/PDFs/AbbVie-Environmental_Stewardship-9.2016.pdf,net_zero_tracker
+net_zero_tracker:I9Q57JVPWHHZ3ZGBW498:2050,I9Q57JVPWHHZ3ZGBW498,Absolute emission reduction,2012.0,2050,100.0,percent,https://www.comerica.com/content/dam/comerica/en/documents/resources/about/sustainability/2020-comerica-cr-report-final.pdf,net_zero_tracker
+net_zero_tracker:LONOZNOJYIBXOHXWDB86:2050,LONOZNOJYIBXOHXWDB86,Absolute emission reduction,2015.0,2050,66.0,percent,https://betterdays.kelloggcompany.com/climate-action,net_zero_tracker
+net_zero_tracker:LZ2C6E0W5W7LQMX5ZI37:2030,LZ2C6E0W5W7LQMX5ZI37,Relative emission reduction,1990.0,2030,33.0,percent,https://www.heidelbergcement.com/de/energie-und-klimaschutz,net_zero_tracker
+net_zero_tracker:N1GZ7BBF3NP8GI976H15:2044,N1GZ7BBF3NP8GI976H15,Absolute emission reduction,2014.0,2044,60.0,percent,https://www.usbank.com/about-us-bank/community/sustainability.html,net_zero_tracker
+net_zero_tracker:NNROIXVWJ7CPSR27SV97:2021,NNROIXVWJ7CPSR27SV97,Absolute emission reduction,2020.0,2021,4.0,percent,,net_zero_tracker
+net_zero_tracker:QG7T915N9S0NY5UKNE63:2024,QG7T915N9S0NY5UKNE63,Absolute emission reduction,2018.0,2024,25.0,percent,https://www.synopsys.com/company/corporate-social-responsibility/environment.html,net_zero_tracker
+net_zero_tracker:RVHJWBXLJ1RFUBSY1F30:2050,RVHJWBXLJ1RFUBSY1F30,Absolute emission reduction,2005.0,2050,50.0,percent,https://www.boeing.com/resources/boeingdotcom/principles/sustainability/assets/data/2021_Boeing_Sustainability_Report.pdf,net_zero_tracker
+net_zero_tracker:WAFCR4OKGSC504WU3E95:2030,WAFCR4OKGSC504WU3E95,Absolute emission reduction,2016.0,2030,60.0,percent,https://corporate.lowes.com/sites/lowes-corp/files/2021-07/2020_CSR_FINAL.pdf,net_zero_tracker
+net_zero_tracker:0BGI85ALH27ZJP15DY16:2030,0BGI85ALH27ZJP15DY16,Absolute emission reduction,2017.0,2030,55.0,percent,https://www.ball.com/na/vision/sustainability/operational-excellence/ghg-emissions,net_zero_tracker
+net_zero_tracker:0EEB8GF0W0NPCIHZX097:2030,0EEB8GF0W0NPCIHZX097,Absolute emission reduction,2018.0,2030,60.0,percent,https://publications.aecom.com/sustainable-legacies/achieve-net-zero-carbon-emissions,net_zero_tracker
+net_zero_tracker:1B4S6S7G0TW5EE83BO58:2030,1B4S6S7G0TW5EE83BO58,Absolute emission reduction,2000.0,2030,80.0,percent,https://www.aepsustainability.com/performance/report/docs/2022_AEP-Sustainability-Report.pdf,net_zero_tracker
+net_zero_tracker:1FRVQX2CRLGC1XLP5727:2021,1FRVQX2CRLGC1XLP5727,Relative emission reduction,2019.0,2021,30.0,percent,https://www.marathonoil.com/sustainability/environment/climate-change/,net_zero_tracker
+net_zero_tracker:1Z4GXXU7ZHVWFCD8TV52:2025,1Z4GXXU7ZHVWFCD8TV52,Absolute emission reduction,2015.0,2025,26.0,percent,https://www.oracle.com/assets/ccr-datasheet-3855392.pdf,net_zero_tracker
+net_zero_tracker:20S05OYHG0MQM4VUIC57:2035,20S05OYHG0MQM4VUIC57,Absolute emission reduction,2017.0,2035,76.0,percent,https://corporate.ford.com/microsites/integrated-sustainability-and-financial-report-2021/files/ir21.pdf,net_zero_tracker
+net_zero_tracker:2138001AVBSD1HSC6Z10:2030,2138001AVBSD1HSC6Z10,Absolute emission reduction,2019.0,2030,33.0,percent,https://matthey.com/en/news/2021/btc-opening,net_zero_tracker
+net_zero_tracker:2138001P49OLAEU33T68:2030,2138001P49OLAEU33T68,Absolute emission reduction,1000.0,2030,50.0,percent,https://www.thephoenixgroup.com/corporate-responsibility/environment.aspx,net_zero_tracker
+net_zero_tracker:2138007JNS19JHNA2336:2025,2138007JNS19JHNA2336,Absolute emission reduction,2014.0,2025,45.0,percent,https://www.sgs.com/en/news/2018/04/sgs-becomes-one-of-100-companies-to-commit-to-science-based-targets-for-greenhouse-gas-emissions,net_zero_tracker
+net_zero_tracker:213800FKA5MF17RJKT63:2030,213800FKA5MF17RJKT63,Absolute emission reduction,2020.0,2030,50.0,percent,https://www.bat.com/group/sites/UK__9D9KCY.nsf/vwPagesWebLive/DOAWWEKR/$file/BAT_Low_Carbon_Transition_Plan_2022.pdf,net_zero_tracker
+net_zero_tracker:213800KBMEV7I92FY281:2025,213800KBMEV7I92FY281,Absolute emission reduction,2016.0,2025,38.0,percent,https://www.kingfisher.com/en/media/news/kingfisher-news/2021/kingfisher-plc-announces-new-2025-carbon-reduction-targets---app.html,net_zero_tracker
+net_zero_tracker:213800LH1BZH3DI6G760:2025,213800LH1BZH3DI6G760,Absolute emission reduction,2019.0,2025,20.0,percent,https://www.bp.com/content/dam/bp/business-sites/en/global/corporate/pdfs/sustainability/group-reports/bp-sustainability-report-2020.pdf,net_zero_tracker
+net_zero_tracker:213800LOZA69QFDC9N34:2025,213800LOZA69QFDC9N34,Absolute emission reduction,2014.0,2025,34.0,percent,https://www.mondigroup.com/en/sustainability/sustainability-reports-and-publications/,net_zero_tracker
+net_zero_tracker:213800M993ICXOMBCP87:2025,213800M993ICXOMBCP87,Absolute emission reduction,2018.0,2025,50.0,percent,https://www.sjp.co.uk/~/media/Files/S/SJP-Corp/document-library/reports/2021/SJP_CDP-Report_April2021.pdf,net_zero_tracker
+net_zero_tracker:213800MY6QVH4FVLD628:2030,213800MY6QVH4FVLD628,Absolute emission reduction,2020.0,2030,30.0,percent,https://www.antofagasta.co.uk/investors/news/2021/antofagasta-sets-new-emissions-targets/,net_zero_tracker
+net_zero_tracker:213800TCZZU84G8Z2M70:2026,213800TCZZU84G8Z2M70,Absolute emission reduction,2021.0,2026,25.0,percent,https://www.royalmail.com/sustainability/environment/net-zero,net_zero_tracker
+net_zero_tracker:213800WFQ334R8UXUG83:2030,213800WFQ334R8UXUG83,Absolute emission reduction,2018.0,2030,40.0,percent,https://www.vinci.com/publi/vinci/extract/2021_annual_report_extract-sustainability.pdf,net_zero_tracker
+net_zero_tracker:213800X3Q9LSAKRUWY91:2030,213800X3Q9LSAKRUWY91,Absolute emission reduction,2015.0,2030,80.0,percent,https://www.kbc.com/en/corporate-sustainability/limiting-our-adverse-impact/our-own-environmental-footprint.html,net_zero_tracker
+net_zero_tracker:213800XC35KGM9NFC641:2030,213800XC35KGM9NFC641,Absolute emission reduction,2020.0,2030,42.0,percent,https://www.segro.com/responsible-segro/carbon,net_zero_tracker
+net_zero_tracker:213800YOEO5OQ72G2R82:2030,213800YOEO5OQ72G2R82,Absolute emission reduction,2018.0,2030,15.0,percent,https://www.riotinto.com/-/media/Content/Documents/Invest/Reports/Climate-Change-reports/RT-climate-report-2020.pdf?rev=c415a8138bd7408496ccb3834511abc0,net_zero_tracker
+net_zero_tracker:2572IBTT8CCZW6AU4141:2030,2572IBTT8CCZW6AU4141,Absolute emission reduction,2010.0,2030,50.0,percent,https://www.pginvestor.com/esg/environmental/climate/default.aspx,net_zero_tracker
+net_zero_tracker:2S72QS2UO2OESLG6Y829:2030,2S72QS2UO2OESLG6Y829,Absolute emission reduction,2019.0,2030,53.0,percent,https://www.verizon.com/about/news/verizon-environmental-initiatives-reduce-global-climate-impact,net_zero_tracker
+net_zero_tracker:2TGYMUGI08PO8X8L6150:2030,2TGYMUGI08PO8X8L6150,Absolute emission reduction,2020.0,2030,30.0,percent,https://www.generalmills.com/en/Responsibility/Sustainability/climate-change,net_zero_tracker
+net_zero_tracker:35380000WKGEAHEMW830:2026,35380000WKGEAHEMW830,Absolute emission reduction,2014.0,2026,25.0,percent,https://www.toyota-industries.com/investors/items/TICO%20Report%202021_EN_full_view.pdf,net_zero_tracker
+net_zero_tracker:3538000246DHJLRTUZ24:2030,3538000246DHJLRTUZ24,Absolute emission reduction,2013.0,2030,71.0,percent,https://www.fujitsu.com/global/documents/about/resources/reports/sustainabilityreport/2018-report/fujitsureport201801-e.pdf,net_zero_tracker
+net_zero_tracker:3538001KQ5SAOZSQTT44:2030,3538001KQ5SAOZSQTT44,Absolute emission reduction,2017.0,2030,34.0,percent,"https://www.engieimpact.com/insights/decarbonization-energy-sector#:~:text=In%20May%202021%2C%20ENGIE%20announced,emissions%20across%20its%20value%20chain.&text=This%20long%2Dterm%20ambition%20is,well%20below%202%C2%B0C.",net_zero_tracker
+net_zero_tracker:3538002NUIQ8JFEJNS94:2030,3538002NUIQ8JFEJNS94,Absolute emission reduction,2013.0,2030,75.0,percent,https://www.shigagin.com/pdf/investor_anuual_ar2021_all.pdf,net_zero_tracker
+net_zero_tracker:3538004IOK08PDY6I723:2031,3538004IOK08PDY6I723,Absolute emission reduction,2014.0,2031,50.0,percent,https://www.aisin.com/en/sustainability/report/pdf/aisin_ar2021_en_a4.pdf,net_zero_tracker
+net_zero_tracker:3538004LR5NXILJDHY88:2030,3538004LR5NXILJDHY88,Absolute emission reduction,2010.0,2030,45.0,percent,https://global.yamaha-motor.com/about/csr/the_environment/plan-2050/#sec-01-07,net_zero_tracker
+net_zero_tracker:3538005PGNIBTZYXAE45:2030,3538005PGNIBTZYXAE45,Absolute emission reduction,2010.0,2030,30.0,percent,https://www.tokyu.co.jp/ir/english/upload_file/m002-m002_09/Tokyu_Integratedreport_2020e.pdf,net_zero_tracker
+net_zero_tracker:35380099TCYR5FHT0A11:2030,35380099TCYR5FHT0A11,Absolute emission reduction,2013.0,2030,30.0,percent,https://www.toray.com/global/sustainability/tcfd/pdf/TCFD_report.pdf,net_zero_tracker
+net_zero_tracker:353800BRAE0QFP3ZLY22:2030,353800BRAE0QFP3ZLY22,Absolute emission reduction,1990.0,2030,70.0,percent,https://www.shimz.co.jp/en/company/csr/environment/performance/eco/,net_zero_tracker
+net_zero_tracker:353800CWW4SRGEYEB512:2030,353800CWW4SRGEYEB512,Absolute emission reduction,2017.0,2030,60.0,percent,https://www.sompo-hd.com/-/media/hd/en/files/csr/communications/pdf/2021/e_report2021.pdf?la=ja-JP,net_zero_tracker
+net_zero_tracker:353800D83H0V3ZV1SV24:2030,353800D83H0V3ZV1SV24,Absolute emission reduction,2016.0,2030,45.0,percent,https://www.globalsuzuki.com/corporate/csr_environment/intro/vision.html,net_zero_tracker
+net_zero_tracker:353800EMK32PDKS9XR54:2030,353800EMK32PDKS9XR54,Absolute emission reduction,2018.0,2030,30.0,percent,https://www.advantest.com/sustainability/pdf/E_all_IAR2020.pdf,net_zero_tracker
+net_zero_tracker:353800GBVL72LLMTYM96:2030,353800GBVL72LLMTYM96,Absolute emission reduction,2015.0,2030,30.0,percent,https://www.kirinholdings.co.jp/english/csv/env/climatechange.html,net_zero_tracker
+net_zero_tracker:353800GPI4Z3MGDGN142:2030,353800GPI4Z3MGDGN142,Absolute emission reduction,2013.0,2030,30.0,percent,https://www.asahi-kasei.com/news/2021/e210525_2.html,net_zero_tracker
+net_zero_tracker:353800HM38HFCB8RGL63:2030,353800HM38HFCB8RGL63,Absolute emission reduction,2017.0,2030,22.0,percent,https://www.kao.com/content/dam/sites/kao/www-kao-com/global/en/sustainability/pdf/klp-pr-2021-e-all.pdf,net_zero_tracker
+net_zero_tracker:353800JX1R4582QVK932:2030,353800JX1R4582QVK932,Absolute emission reduction,2018.0,2030,30.0,percent,https://www.terumo.com/sustainability/reports/pdf/SustainabilityDataBook_2020_E.pdf,net_zero_tracker
+net_zero_tracker:353800K1RXV3E3JAE812:2030,353800K1RXV3E3JAE812,Absolute emission reduction,2010.0,2030,50.0,percent,https://www.mazda.com/en/csr/environment/sustainable/,net_zero_tracker
+net_zero_tracker:353800KOFMRGOXSJ5Z65:2030,353800KOFMRGOXSJ5Z65,Absolute emission reduction,2017.0,2030,35.0,percent,https://www.mec.co.jp/e/sustainability/activities/environment/climate-change/,net_zero_tracker
+net_zero_tracker:353800KTF7EYIIYHY088:2030,353800KTF7EYIIYHY088,Absolute emission reduction,2013.0,2030,50.0,percent,https://www.tohoku-epco.co.jp/ir/report/integrated_report/pdf/tohoku_report2021en.pdf,net_zero_tracker
+net_zero_tracker:353800ND4ZKNZDYKMF33:2030,353800ND4ZKNZDYKMF33,Absolute emission reduction,2019.0,2030,30.0,percent,https://www.mitsuifudosan.co.jp/english/corporate/esg_csr/environment/05.html,net_zero_tracker
+net_zero_tracker:353800P843RLCDBLNT17:2030,353800P843RLCDBLNT17,Absolute emission reduction,2015.0,2030,100.0,percent,https://www.smth.jp/english/-/media/th/english/news/2021/E211020.pdf,net_zero_tracker
+net_zero_tracker:353800P8O843TMAZ6S09:2030,353800P8O843TMAZ6S09,Absolute emission reduction,2013.0,2030,40.0,percent,https://jp.mitsuichemicals.com/en/sustainability/mci_sustainability/climate_change/carbon_neutrality.htm,net_zero_tracker
+net_zero_tracker:353800PFUKP5ONPJNZ86:2025,353800PFUKP5ONPJNZ86,Absolute emission reduction,2013.0,2025,50.0,percent,https://www.kepco.co.jp/english/csr/,net_zero_tracker
+net_zero_tracker:353800SENYJ2DSM6PS44:2031,353800SENYJ2DSM6PS44,Absolute emission reduction,2014.0,2031,50.0,percent,https://www.jreast.co.jp/e/environment/pdf_2020/all.pdf,net_zero_tracker
+net_zero_tracker:353800UQ4BZIJTAQEG85:2030,353800UQ4BZIJTAQEG85,Absolute emission reduction,2016.0,2030,34.0,percent,https://www.unicharm.co.jp/content/dam/sites/www_unicharm_co_jp/pdf/csr-eco/report/en-ucsus2020_all_English.pdf,net_zero_tracker
+net_zero_tracker:353800UT0TLROREPIC92:2025,353800UT0TLROREPIC92,Absolute emission reduction,2018.0,2025,30.0,percent,https://www.ajinomoto.com/sustainability/materiality/climate_change.php,net_zero_tracker
+net_zero_tracker:353800VHYYADPR6MXQ47:2030,353800VHYYADPR6MXQ47,Absolute emission reduction,2019.0,2030,30.0,percent,https://www.inpex.co.jp/english/csr/climatechange/,net_zero_tracker
+net_zero_tracker:353800W25FCOFE32EM73:2030,353800W25FCOFE32EM73,Absolute emission reduction,2019.0,2030,50.0,percent,https://www.asahigroup-holdings.com/en/csr/environment/climatechange.html,net_zero_tracker
+net_zero_tracker:353800YNKX4RQUGAR072:2030,353800YNKX4RQUGAR072,Absolute emission reduction,2019.0,2030,29.0,percent,https://www.mitsubishichem-hd.co.jp/english/news_release/01139.html,net_zero_tracker
+net_zero_tracker:378900F4544561A97588:2030,378900F4544561A97588,Absolute emission reduction,2017.0,2030,30.0,percent,"https://www.sasol.com/media-centre/media-releases/sasols-commitment-decarbonisation-reaffirmed-overwhelming-shareholder-support-climate-action#:~:text=Sasol%20committed%20to%20a%202050,Energy%20and%20Chemicals%20business%20units.",net_zero_tracker
+net_zero_tracker:3BNYRYQHD39K4LCKQF12:2030,3BNYRYQHD39K4LCKQF12,Absolute emission reduction,2019.0,2030,15.0,percent,https://www.marathonpetroleum.com/Sustainability/Lowering-Carbon-Intensity/,net_zero_tracker
+net_zero_tracker:3E70L4WYANTIWWIPHC81:2030,3E70L4WYANTIWWIPHC81,Absolute emission reduction,2020.0,2030,50.0,percent,https://tinyurl.com/2ktzzy7p,net_zero_tracker
+net_zero_tracker:3PPKBHUG1HD6BO7RNR87:2025,3PPKBHUG1HD6BO7RNR87,Absolute emission reduction,2020.0,2025,20.0,percent,https://www.textron.com/assets/CR/2019/ProductSustainabilityHighlights.html,net_zero_tracker
+net_zero_tracker:3SOUA6IRML7435B56G12:2022,3SOUA6IRML7435B56G12,Absolute emission reduction,2015.0,2022,15.0,percent,https://www.exeloncorp.com/newsroom/exelon-utilities-announces-goal-to-achieve-net-zero-emissions-by-2050,net_zero_tracker
+net_zero_tracker:4DR1VPDQMHD3N3QW8W95:2030,4DR1VPDQMHD3N3QW8W95,Relative emission reduction,2008.0,2030,40.0,percent,https://carnival-sustainability-2022.nyc3.digitaloceanspaces.com/assets/content/pdf/FY-2021-Sustainability-Report_Carnival-Corporation-and-plc.pdf,net_zero_tracker
+net_zero_tracker:4P4N3ORD02UGQT1T1W12:2030,4P4N3ORD02UGQT1T1W12,Absolute emission reduction,2019.0,2030,25.0,percent,https://www.marubeni.com/en/news/2021/release/00022.html,net_zero_tracker
+net_zero_tracker:52990016II9MJ2OSWA10:2035,52990016II9MJ2OSWA10,Absolute emission reduction,2019.0,2035,68.0,percent,https://www.cbre.com/-/media/project/cbre/dotcom/global/about/corporate-responsibility/cbre-2020-corporate-responsibility-report.pdf,net_zero_tracker
+net_zero_tracker:5299001GRRO0Z25YZT52:2030,5299001GRRO0Z25YZT52,Absolute emission reduction,2018.0,2030,50.0,percent,https://www.knorr-bremse.com/en/responsibility/,net_zero_tracker
+net_zero_tracker:5299001X9L42HXEBCZ51:2019,5299001X9L42HXEBCZ51,Absolute emission reduction,2015.0,2019,75.0,percent,https://www.ceconomy.de/en/sustainability/,net_zero_tracker
+net_zero_tracker:5299002D52YIP6DWMV49:2031,5299002D52YIP6DWMV49,Absolute emission reduction,2016.0,2031,40.0,percent,https://www.meiji.com/global/sustainability/caring_for_the_earth/climate_change/,net_zero_tracker
+net_zero_tracker:52990037G8JRM3TWGY86:2030,52990037G8JRM3TWGY86,Absolute emission reduction,2013.0,2030,30.0,percent,https://www.7andi.com/library/dbps_data/_template_/_res/en/csr/csrreport/2020/pdf/2020_all_01.pdf,net_zero_tracker
+net_zero_tracker:5299003D9N4JBS256X18:2030,5299003D9N4JBS256X18,Absolute emission reduction,2019.0,2030,46.0,percent,https://www.japanpost.jp/sustainability/environment/greenhouse_gas/#charge,net_zero_tracker
+net_zero_tracker:5299003FU7V4I45FU310:2030,5299003FU7V4I45FU310,Absolute emission reduction,2019.0,2030,50.0,percent,https://www.kddi.com/extlib/files/english/corporate/csr/csr_report/2021/pdf/report2021_en.pdf,net_zero_tracker
+net_zero_tracker:5299004EMJ3R4RVR5Y75:2030,5299004EMJ3R4RVR5Y75,Absolute emission reduction,2013.0,2030,50.0,percent,https://www.tepco.co.jp/en/hd/about/ir/library/integratedreport/index-e.html,net_zero_tracker
+net_zero_tracker:5299005F1HCVF4M4QN79:2030,5299005F1HCVF4M4QN79,Absolute emission reduction,2013.0,2030,72.0,percent,https://www.nri.com/en/sustainability/environment/policy,net_zero_tracker
+net_zero_tracker:5299006EQ03K3SSUYS12:2028,5299006EQ03K3SSUYS12,Absolute emission reduction,2018.0,2028,85.0,percent,https://www.merlinproperties.com/wp-content/uploads/2022/05/Pathway-to-Net-Zero-02_22-1.pdf,net_zero_tracker
+net_zero_tracker:5299006UDSEJCTTEJS30:2021,5299006UDSEJCTTEJS30,Absolute emission reduction,2011.0,2021,90.0,percent,https://www.verbund.com/-/media/verbund/ueber-verbund/verantwortung/umwelt/klimaschutz/verbund-climate-report-en.ashx?ori=1&la=en,net_zero_tracker
+net_zero_tracker:5299006ZTN6MO1N5BR16:2031,5299006ZTN6MO1N5BR16,Absolute emission reduction,2014.0,2031,17.0,percent,https://mmc.disclosure.site/en/themes/92,net_zero_tracker
+net_zero_tracker:5299009MXFL34SA71416:2030,5299009MXFL34SA71416,Absolute emission reduction,2019.0,2030,35.0,percent,https://www.irwebcasting.com/20210125/2/1045f40096/media/210125_aeon_en03.pdf,net_zero_tracker
+net_zero_tracker:529900A76GOP0PGNHT63:2030,529900A76GOP0PGNHT63,Absolute emission reduction,2013.0,2030,50.0,percent,https://www.chuden.co.jp/english/resource/esg/environment/zeroemissions/zeroemissions_01.pdf,net_zero_tracker
+net_zero_tracker:529900CXROT5S2HMMP26:2030,529900CXROT5S2HMMP26,Absolute emission reduction,2019.0,2030,50.0,percent,https://www.ms-ad-hd.com/en/ir/library/disclosure/main/015/teaserItems2/0/link/1115_en.pdf,net_zero_tracker
+net_zero_tracker:529900F3AIQECS8ZSV61:2025,529900F3AIQECS8ZSV61,Absolute emission reduction,2019.0,2025,20.0,percent,https://www.umicore.com/en/newsroom/news/umicore-unveils-bold-sustainability-ambitions-and-commits-to-achieving-carbon-neutrality-by-2035/,net_zero_tracker
+net_zero_tracker:529900F60CID3NCZM330:2025,529900F60CID3NCZM330,Absolute emission reduction,2018.0,2025,50.0,percent,https://socialresponsibility.carmax.com/,net_zero_tracker
+net_zero_tracker:529900FNDVTQJOVVPZ19:2023,529900FNDVTQJOVVPZ19,Absolute emission reduction,2020.0,2023,23.0,percent,https://www.thalesgroup.com/fr/group/journaliste/press-release/thales-comment-hautes-technologies-peuvent-reduire-court-terme,net_zero_tracker
+net_zero_tracker:529900G3SW56SHYNPR95:2023,529900G3SW56SHYNPR95,Absolute emission reduction,2021.0,2023,70.0,percent,https://deutsche-boerse.com/dbg-de/media/pressemitteilungen/Deutsche-B-rse-will-bis-2025-netto-klimaneutral-werden-2653534,net_zero_tracker
+net_zero_tracker:529900GB7KCA94ACC940:2030,529900GB7KCA94ACC940,Absolute emission reduction,2019.0,2030,50.0,percent,https://www.rwe.com/-/media/RWE/documents/09-responsibility-and-sustainability/cr-reports/EN/cr-report-2021.pdf,net_zero_tracker
+net_zero_tracker:529900GMNDOYQSAJAE76:2030,529900GMNDOYQSAJAE76,Absolute emission reduction,2013.0,2030,50.0,percent,https://www.sekisuihouse.co.jp/library/english/company/sustainable/2021/2021_all.pdf,net_zero_tracker
+net_zero_tracker:529900JH1GSC035SSP77:2030,529900JH1GSC035SSP77,Absolute emission reduction,2018.0,2030,30.0,percent,https://www.responsibilityreports.com/HostedData/ResponsibilityReportArchive/c/NYSE_CAJ_2021.pdf,net_zero_tracker
+net_zero_tracker:529900JI1GG6F7RKVI53:2030,529900JI1GG6F7RKVI53,Absolute emission reduction,2016.0,2030,25.0,percent,https://www.loreal-finance.com/eng/news-events/loreal-recognized-global-compact-lead-united-nations-and-steps-its-climate-action,net_zero_tracker
+net_zero_tracker:529900K9B0N5BT694847:2025,529900K9B0N5BT694847,Absolute emission reduction,2019.0,2025,25.0,percent,https://www.allianz.com/content/dam/onemarketing/azcom/Allianz_com/sustainability/documents/Allianz_Group_Sustainability_Report_2020-web.pdf,net_zero_tracker
+net_zero_tracker:529900LVC9GIIYUGE243:2030,529900LVC9GIIYUGE243,Absolute emission reduction,2018.0,2030,70.0,percent,https://ojiholdings.disclosure.site/en/themes/198/,net_zero_tracker
+net_zero_tracker:529900MUF4C20K50JS49:2025,529900MUF4C20K50JS49,Relative emission reduction,2019.0,2025,12.0,percent,https://www.munichre.com/content/dam/munichre/contentlounge/website-pieces/documents/munich_re_sustainability_report_2021.pdf/_jcr_content/renditions/original./munich_re_sustainability_report_2021.pdf,net_zero_tracker
+net_zero_tracker:529900NNUPAGGOMPXZ31:2025,529900NNUPAGGOMPXZ31,Absolute emission reduction,2018.0,2025,30.0,percent,https://www.volkswagenag.com/presence/nachhaltigkeit/documents/sustainability-report/2021/focus-topics/220310_VW_NB21_Decarbonization_EN.pdf,net_zero_tracker
+net_zero_tracker:529900O5RR7R39FRDM42:2030,529900O5RR7R39FRDM42,Absolute emission reduction,2017.0,2030,40.0,percent,https://hmgroup.com/sustainability/leading-the-change/goals-and-ambitions/,net_zero_tracker
+net_zero_tracker:529900OAREIS0MOPTW25:2030,529900OAREIS0MOPTW25,Absolute emission reduction,2020.0,2030,50.0,percent,https://www.merckgroup.com/en/sustainability/environment.html,net_zero_tracker
+net_zero_tracker:529900PM64WH8AF1E917:2030,529900PM64WH8AF1E917,Absolute emission reduction,2018.0,2030,25.0,percent,https://www.basf.com/global/en/media/news-releases/2021/03/p-21-166.html,net_zero_tracker
+net_zero_tracker:529900QVNRBND50TXP03:2025,529900QVNRBND50TXP03,Absolute emission reduction,2020.0,2025,50.0,percent,https://www.zurich.com/en/sustainability/sustainable-operations/net-zero,net_zero_tracker
+net_zero_tracker:529900R27DL06UVNT076:2030,529900R27DL06UVNT076,Absolute emission reduction,2018.0,2030,40.0,percent,https://www.daimler.com/sustainability/climate/ambition-2039-our-path-to-co2-neutrality.html,net_zero_tracker
+net_zero_tracker:529900S21EQ1BO4ESM68:2025,529900S21EQ1BO4ESM68,Absolute emission reduction,2015.0,2025,15.0,percent,https://sustainable-performance.totalenergies.com/en/our-challenges/environment-and-climate/climate,net_zero_tracker
+net_zero_tracker:529900S5R9YHJHYKKG94:2030,529900S5R9YHJHYKKG94,Relative emission reduction,2019.0,2030,58.0,percent,https://www.cez.cz/en/media/press-releases/cez-presents-clean-energy-of-tomorrow-its-production-portfolio-is-to-be-rebuilt-to-low-emissions-by-2030-144329,net_zero_tracker
+net_zero_tracker:529900S7NFNQ4FT6OP83:2030,529900S7NFNQ4FT6OP83,Absolute emission reduction,2015.0,2030,25.0,percent,https://www.dnp.co.jp/eng/sustainability/,net_zero_tracker
+net_zero_tracker:529900SM0FDLLYATXU36:2025,529900SM0FDLLYATXU36,Relative emission reduction,2017.0,2025,22.0,percent,https://www.baywa.com/en/responsibility/at-a-glance,net_zero_tracker
+net_zero_tracker:529900TF7XJKIOWMLQ79:2030,529900TF7XJKIOWMLQ79,Absolute emission reduction,2020.0,2030,62.0,percent,https://www.taisei.co.jp/english/csr/performance/iso26000/environment/,net_zero_tracker
+net_zero_tracker:529900UBKMFM0ST6H474:2030,529900UBKMFM0ST6H474,Absolute emission reduction,2013.0,2030,45.0,percent,https://www.fujifilm.com/files-holdings/en/sustainability/report/2021/sustainabilityreport2021_svpstories_en.pdf,net_zero_tracker
+net_zero_tracker:529900YRFFGH5AXU4S86:2025,529900YRFFGH5AXU4S86,Absolute emission reduction,2017.0,2025,80.0,percent,https://corporate.zalando.com/en/sustainability/reducing-our-carbon-footprint,net_zero_tracker
+net_zero_tracker:529900YT4O5S0LCXWD54:2030,529900YT4O5S0LCXWD54,Absolute emission reduction,2013.0,2030,25.0,percent,https://www.obayashi.co.jp/en/sustainability/environment/tcfd.html,net_zero_tracker
+net_zero_tracker:5493000CGCQY2OQU7669:2025,5493000CGCQY2OQU7669,Absolute emission reduction,2019.0,2025,25.0,percent,https://www.jabil.com/about-us/sustainability/our-operations-and-resources.html,net_zero_tracker
+net_zero_tracker:5493000KUC3Z24U77V93:2024,5493000KUC3Z24U77V93,Relative emission reduction,2019.0,2024,35.0,percent,https://reporting.swisslife.com/download/2021AR/en/FY21_SustainabilityReport_EN.pdf,net_zero_tracker
+net_zero_tracker:5493000QYMPFRTEY4K28:2031,5493000QYMPFRTEY4K28,Absolute emission reduction,2018.0,2031,55.0,percent,https://www.nec.com/en/global/csr/eco/risk.html,net_zero_tracker
+net_zero_tracker:5493001EZOOA66PTBR68:2025,5493001EZOOA66PTBR68,Absolute emission reduction,2019.0,2025,50.0,percent,https://atos.net/en/lp/integrated-report-2019/our-environment,net_zero_tracker
+net_zero_tracker:5493001Z3ZE83NGK8Y12:2025,5493001Z3ZE83NGK8Y12,Absolute emission reduction,2020.0,2025,25.0,percent,https://www.prudentialplc.com/en/news-and-insights/all-news/news-releases/2021/07-05-2021,net_zero_tracker
+net_zero_tracker:5493002CONDB4N2HKI23:2030,5493002CONDB4N2HKI23,Relative emission reduction,2019.0,2030,50.0,percent,https://www.parker.com/parkerimages/Parker.com/Countries-2011/United%20States/About%20Us/Documents/Parker%20Sustainability%20Report%202020.pdf,net_zero_tracker
+net_zero_tracker:5493002F0SC4JTBU5137:2024,5493002F0SC4JTBU5137,Absolute emission reduction,2019.0,2024,20.0,percent,https://www.stryker.com/content/m/c/2020-comprehensive-annual-report/environmental-sustainability/carbon-neutrality.html,net_zero_tracker
+net_zero_tracker:5493003S21INSLK2IP73:2030,5493003S21INSLK2IP73,Absolute emission reduction,2019.0,2030,15.0,percent,https://corporate.dow.com/documents/about/066-00338-01-2020-esg-report.pdf,net_zero_tracker
+net_zero_tracker:54930044KVSC06Z79I06:2030,54930044KVSC06Z79I06,Absolute emission reduction,2020.0,2030,50.0,percent,https://s21.q4cdn.com/507168367/files/doc_financials/2021/ar/Clorox-2021-Integrated-Annual-Report.pdf,net_zero_tracker
+net_zero_tracker:5493004JF0SDFLM8GD76:2030,5493004JF0SDFLM8GD76,Absolute emission reduction,2019.0,2030,30.0,percent,https://www.dupont.com/about/sustainability/acting-on-climate.html.html,net_zero_tracker
+net_zero_tracker:5493004LQ0B4T7QPQV17:2030,5493004LQ0B4T7QPQV17,Absolute emission reduction,2010.0,2030,50.0,percent,https://sustainability-cms-komatsu-s3.s3-ap-northeast-1.amazonaws.com/en/csr/pdf/KOMATSUCSR2022_en.pdf,net_zero_tracker
+net_zero_tracker:5493004SE33MRLPB1W98:2030,5493004SE33MRLPB1W98,Absolute emission reduction,2018.0,2030,60.0,percent,https://www.sojitz.com/en/csr/environment/carbon_neutrality/,net_zero_tracker
+net_zero_tracker:5493005SP87FL5TOS202:2035,5493005SP87FL5TOS202,Absolute emission reduction,2019.0,2035,60.0,percent,https://www.sumitomocorp.com/en/jp/sustainability/environmental-management/climate,net_zero_tracker
+net_zero_tracker:5493005X2GO78EFZ3E94:2025,5493005X2GO78EFZ3E94,Absolute emission reduction,2000.0,2025,25.0,percent,https://s201.q4cdn.com/858635754/files/doc_downloads/PayPal-2021-Global-Impact-Report.pdf,net_zero_tracker
+net_zero_tracker:5493006AIPA1V92YPP18:2030,5493006AIPA1V92YPP18,Absolute emission reduction,2013.0,2030,30.0,percent,https://www.sdk.co.jp/english/csr/environment/climate.html,net_zero_tracker
+net_zero_tracker:5493006IEVQEFQO40L83:2030,5493006IEVQEFQO40L83,Absolute emission reduction,2020.0,2030,50.0,percent,https://www.cognizant.com/us/en/documents/carbon-reduction-plan.pdf,net_zero_tracker
+net_zero_tracker:5493006IH2N2WMIBB742:2030,5493006IH2N2WMIBB742,Absolute emission reduction,2019.0,2030,45.0,percent,https://www.valeo.com/fr/valeo-sengage-a-atteindre-la-neutralite-carbone-en-2050-et-aura-deja-fait-45-du-chemin-dici-a-2030/,net_zero_tracker
+net_zero_tracker:5493006W3QUS5LMH6R84:2030,5493006W3QUS5LMH6R84,Absolute emission reduction,2013.0,2030,35.0,percent,https://global.toyota/pages/global_toyota/sustainability/report/sdb/sdb22_en.pdf,net_zero_tracker
+net_zero_tracker:54930070J9H97ZO93T57:2050,54930070J9H97ZO93T57,Absolute emission reduction,2005.0,2050,50.0,percent,https://www.jetblue.com/sustainability/climate-leadership,net_zero_tracker
+net_zero_tracker:54930070NSV60J38I987:2035,54930070NSV60J38I987,Absolute emission reduction,2018.0,2035,72.0,percent,https://www.gmsustainability.com/_pdf/resources-and-downloads/GM_2020_SR.pdf,net_zero_tracker
+net_zero_tracker:549300772D1G8JPIUR96:2025,549300772D1G8JPIUR96,Absolute emission reduction,2021.0,2025,25.0,percent,https://www.aegon.com/investors/press-releases/2021/aegon-commits-to-group-wide-net-zero-emissions-objective-by-2050/,net_zero_tracker
+net_zero_tracker:5493007HIVTX6SY6XD66:2025,5493007HIVTX6SY6XD66,Absolute emission reduction,2016.0,2025,100.0,percent,https://www.novartis.com/our-company/corporate-responsibility/environmental-sustainability/climate,net_zero_tracker
+net_zero_tracker:5493007JDSMX8Z5Z1902:2022,5493007JDSMX8Z5Z1902,Absolute emission reduction,2020.0,2022,8.0,percent,https://www.campbellsoupcompany.com/newsroom/news/reducing-greenhouse-gas-emissions-in-our-operations/,net_zero_tracker
+net_zero_tracker:5493008C12PZMWP3WY03:2025,5493008C12PZMWP3WY03,Relative emission reduction,2018.0,2025,12.0,percent,https://www.kcsouthern.com/corporate-responsibility/our-commitment/KCS-2019-Sustainability-Report.pdf,net_zero_tracker
+net_zero_tracker:5493008FFSI8SQ74AT93:2030,5493008FFSI8SQ74AT93,Absolute emission reduction,2013.0,2030,26.0,percent,https://global.kawasaki.com/en/corp/sustainability/environment/20_houkokusyo.pdf,net_zero_tracker
+net_zero_tracker:5493008H3828EMEXB082:2025,5493008H3828EMEXB082,Absolute emission reduction,2017.0,2025,25.0,percent,https://www.ab-inbev.com/assets/pdfs/Net%20Zero%20Executive%20Summary_FINAL%2012pm.pdf,net_zero_tracker
+net_zero_tracker:5493008IRKIY0G3TE305:2030,5493008IRKIY0G3TE305,Absolute emission reduction,2019.0,2030,33.0,percent,https://www.anahd.co.jp/group/en/pr/202104/20210426.html,net_zero_tracker
+net_zero_tracker:5493008IUOJ5VWTRC333:2030,5493008IUOJ5VWTRC333,Relative emission reduction,2015.0,2030,10.0,percent,https://www.interpublic.com/wp-content/uploads/2021/08/CDP-Climate-Change-Questionnaire-2021_Interpublic-Group.pdf,net_zero_tracker
+net_zero_tracker:5493008T4YG3AQUI7P67:2025,5493008T4YG3AQUI7P67,Absolute emission reduction,2020.0,2025,30.0,percent,https://www.cellnextelecom.com/content/uploads/2021/07/Cellnex-Telecom_-Environmental-and-Climate-Change-Report.pdf,net_zero_tracker
+net_zero_tracker:5493009ML300G373MZ12:2030,5493009ML300G373MZ12,Absolute emission reduction,2005.0,2030,50.0,percent,https://www.alliantenergy.com/AboutAlliantEnergy/ResponsibilityReport/CleanEnergyVisionGoals,net_zero_tracker
+net_zero_tracker:549300B6HWYEE57O8J84:2020,549300B6HWYEE57O8J84,Absolute emission reduction,2015.0,2020,35.0,percent,https://www.skf.com/uk/organisation/sustainability/decarbonizing,net_zero_tracker
+net_zero_tracker:549300B8P6MUJ1YWTS08:2030,549300B8P6MUJ1YWTS08,Absolute emission reduction,2019.0,2030,50.0,percent,https://newclimate.org/wp-content/uploads/2022/02/CorporateClimateResponsibilityMonitor2022.pdf,net_zero_tracker
+net_zero_tracker:549300BMOJ05INE4YK86:2026,549300BMOJ05INE4YK86,Absolute emission reduction,2009.0,2026,35.0,percent,https://esg.vno.com/,net_zero_tracker
+net_zero_tracker:549300BX44RGX6ANDV88:2025,549300BX44RGX6ANDV88,Absolute emission reduction,2016.0,2025,55.0,percent,https://www.hpe.com/us/en/living-progress/carbon-footprint.html,net_zero_tracker
+net_zero_tracker:549300BX44RGX6ANDV88:2030,549300BX44RGX6ANDV88,Absolute emission reduction,2019.0,2030,50.0,percent,https://press.hp.com/us/en/press-releases/2021/hp-inc-announces-ambitious-climate-action-goals.html,net_zero_tracker
+net_zero_tracker:549300CEE2ENIUJNXB84:2030,549300CEE2ENIUJNXB84,Absolute emission reduction,2019.0,2030,50.0,percent,https://www.toyota-tsusho.com/english/ir/library/integrated-report/pdf/ar2021e_all.pdf,net_zero_tracker
+net_zero_tracker:549300CSY4INHEHQQT13:2020,549300CSY4INHEHQQT13,Absolute emission reduction,2014.0,2020,18.0,percent,https://www.kubota.com/sustainability/environment/ghg/index.html,net_zero_tracker
+net_zero_tracker:549300CZ8QS1GE53O776:2030,549300CZ8QS1GE53O776,Absolute emission reduction,2019.0,2030,50.0,percent,https://www.jacobs.com/sites/default/files/2022-04/Jacobs%20Climate%20Action%20Plan.pdf,net_zero_tracker
+net_zero_tracker:549300D8GOWWH0SJB189:2025,549300D8GOWWH0SJB189,Absolute emission reduction,2005.0,2025,50.0,percent,https://www.nisource.com/docs/librariesprovider2/sustainability-archives/2021/2021-cdp-climate-change-response.pdf?sfvrsn=4,net_zero_tracker
+net_zero_tracker:549300DFVPOB67JL3A42:2030,549300DFVPOB67JL3A42,Absolute emission reduction,2017.0,2030,25.0,percent,https://www.imperialbrandsplc.com/content/dam/imperialbrands/corporate2022/documents/investors/reports/annual-report-2021.pdf.downloadasset.pdf,net_zero_tracker
+net_zero_tracker:549300DHPOF90OYYD780:2030,549300DHPOF90OYYD780,Absolute emission reduction,2011.0,2030,50.0,percent,https://www.bridgestone.com/responsibilities/library/pdf/sr2020.pdf,net_zero_tracker
+net_zero_tracker:549300DRQQI75D2JP341:2030,549300DRQQI75D2JP341,Absolute emission reduction,2019.0,2030,35.0,percent,https://filecache.investorroom.com/mr5ir_truist/611/Truist%202021%20ESG%20and%20CSR%20Report%20%28ADA%29.pdf,net_zero_tracker
+net_zero_tracker:549300DSFX2IE88NSX47:2030,549300DSFX2IE88NSX47,Relative emission reduction,2015.0,2030,50.0,percent,https://www.borgwarner.com/company/sustainability#environmental-stewardship,net_zero_tracker
+net_zero_tracker:549300DV9GIB88LZ5P30:2025,549300DV9GIB88LZ5P30,Absolute emission reduction,2018.0,2025,10.0,percent,https://www.mondelezinternational.com/-/media/Mondelez/Snacking-Made-Right/SMR-Report/2021/2021-MDLZ-Snacking-Made-Right-ESG-Report.pdf,net_zero_tracker
+net_zero_tracker:549300E9PC51EN656011:2030,549300E9PC51EN656011,Absolute emission reduction,2019.0,2030,55.0,percent,https://integrated-report.sanofi.com/strategy/building-sustainability-for-a-healthy-planet/,net_zero_tracker
+net_zero_tracker:549300EEJH4FEPDBBR25:2025,549300EEJH4FEPDBBR25,Absolute emission reduction,2015.0,2025,90.0,percent,https://www.telefonica.com/documents/364672/413993/telefonica-cdp-climate-change-questionnaire-2020.pdf/4fa2d4f0-3bbd-d391-9931-8671bdb18f65,net_zero_tracker
+net_zero_tracker:549300EFP3TNG7JGVE49:2030,549300EFP3TNG7JGVE49,Absolute emission reduction,2017.0,2030,25.0,percent,https://www.coca-colahellenic.com/en/media/news/sustainability_news/2021/coca-cola-hbc-commits-to-net-zero-emissions-by-2040,net_zero_tracker
+net_zero_tracker:549300EI6OKH5K5Q2G38:2030,549300EI6OKH5K5Q2G38,Absolute emission reduction,2019.0,2030,47.0,percent,https://www.mtn.com/mtn-commits-to-net-zero-emissions-by-2040-to-contribute-to-a-sustainable-future/,net_zero_tracker
+net_zero_tracker:549300EJG376EN5NQE29:2030,549300EJG376EN5NQE29,Absolute emission reduction,2019.0,2030,47.0,percent,https://cvshealth.com/sites/default/files/2020-csr-report.pdf,net_zero_tracker
+net_zero_tracker:549300EJG9IEYQL5XT21:2025,549300EJG9IEYQL5XT21,Absolute emission reduction,2018.0,2025,70.0,percent,https://www.tiffany.co.uk/sustainability/the-planet/efficient-energy/,net_zero_tracker
+net_zero_tracker:549300EVUN2BTLJ3GT74:2030,549300EVUN2BTLJ3GT74,Absolute emission reduction,2019.0,2030,50.0,percent,https://www.equinix.co.uk/newsroom/press-releases/2021/06/equinix-sets-2030-global-climate-neutral-target,net_zero_tracker
+net_zero_tracker:549300FA4CTCW903Y781:2025,549300FA4CTCW903Y781,Absolute emission reduction,2011.0,2025,35.0,percent,https://www.caesars.com/corporate/corporate-social-responsibility/planet/climate,net_zero_tracker
+net_zero_tracker:549300FC3G3YU2FBZD92:2030,549300FC3G3YU2FBZD92,Absolute emission reduction,2007.0,2030,50.0,percent,https://www.southerncompany.com/sustainability/net-zero-and-environmental-priorities/net-zero-transition.html,net_zero_tracker
+net_zero_tracker:549300FONLMVK7YYYH41:2030,549300FONLMVK7YYYH41,Absolute emission reduction,2019.0,2030,30.0,percent,https://www.suntory.com/csr/activity/environment/management/vision/,net_zero_tracker
+net_zero_tracker:549300GCEDD8YCF5WU84:2030,549300GCEDD8YCF5WU84,Absolute emission reduction,2019.0,2030,50.0,percent,https://www.moodys.com/sites/products/ProductAttachments/Sustainability/moodys_decarbonization_plan.pdf,net_zero_tracker
+net_zero_tracker:549300GHBMY8T5GXDE41:2030,549300GHBMY8T5GXDE41,Absolute emission reduction,2021.0,2030,60.0,percent,https://www.unitedhealthgroup.com/content/dam/UHG/PDF/About/UNH-enivronmental-impact-statement.pdf,net_zero_tracker
+net_zero_tracker:549300GLKVIO8YRCYN02:2030,549300GLKVIO8YRCYN02,Absolute emission reduction,2019.0,2030,55.0,percent,https://www.keysight.com/us/en/assets/7018-06607/brochures/5992-3927.pdf,net_zero_tracker
+net_zero_tracker:549300H5LSF8DP3RIJ34:2025,549300H5LSF8DP3RIJ34,Relative emission reduction,2014.0,2025,20.0,percent,https://www.tel.com/csr/environment/,net_zero_tracker
+net_zero_tracker:549300HGGKEL4FYTTQ83:2025,549300HGGKEL4FYTTQ83,Absolute emission reduction,2018.0,2025,20.0,percent,http://sustainability.steeldynamics.com/valuing-our-environment/,net_zero_tracker
+net_zero_tracker:549300I4GMO6D34U1T02:2025,549300I4GMO6D34U1T02,Absolute emission reduction,2019.0,2025,25.0,percent,https://www.lamresearch.com/esg-report/downloads/Lam-Research-2021-ESG-Report.pdf,net_zero_tracker
+net_zero_tracker:549300I7ROF15MAEVP56:2030,549300I7ROF15MAEVP56,Absolute emission reduction,1990.0,2030,40.0,percent,https://www.edison.com/content/dam/eix/documents/sustainability/eix-2021-sustainability-report.pdf,net_zero_tracker
+net_zero_tracker:549300IGLYTZUK3PVP70:2025,549300IGLYTZUK3PVP70,Absolute emission reduction,2005.0,2025,60.0,percent,https://www.wecenergygroup.com/home/generation-reshaping-plan.htm,net_zero_tracker
+net_zero_tracker:549300IRDTHJQ1PVET45:2030,549300IRDTHJQ1PVET45,Relative emission reduction,2018.0,2030,15.0,percent,https://www.responsibilityreports.com/HostedData/ResponsibilityReports/PDF/NYSE_FCX_2020.pdf,net_zero_tracker
+net_zero_tracker:549300ITS31QK8VRBQ14:2030,549300ITS31QK8VRBQ14,Absolute emission reduction,2016.0,2030,60.0,percent,https://newscorp.com/news-corp-sustainability/,net_zero_tracker
+net_zero_tracker:549300IULC8F8IGXKI15:2023,549300IULC8F8IGXKI15,Absolute emission reduction,2020.0,2023,50.0,percent,https://www.lundin-energy.com/sustainability/climate-change/decarbonisation-strategy/,net_zero_tracker
+net_zero_tracker:549300IX8SD6XXD71I78:2023,549300IX8SD6XXD71I78,Absolute emission reduction,2005.0,2023,32.0,percent,https://dtecleanenergy.com/,net_zero_tracker
+net_zero_tracker:549300J0DYC0N31V7G13:2021,549300J0DYC0N31V7G13,Relative emission reduction,2020.0,2021,48.0,percent,https://www.workday.com/en-gb/company/corporate-responsibility/sustainability.html,net_zero_tracker
+net_zero_tracker:549300J4U55H3WP1XT59:2024,549300J4U55H3WP1XT59,Absolute emission reduction,2019.0,2024,20.0,percent,https://www.bayer.com/en/sustainability/climate-protection,net_zero_tracker
+net_zero_tracker:549300JE8XHZZ7OHN517:2030,549300JE8XHZZ7OHN517,Absolute emission reduction,2019.0,2030,46.0,percent,https://www.yum.com/wps/portal/yumbrands/Yumbrands/citizenship-and-sustainability/planet,net_zero_tracker
+net_zero_tracker:549300JF6LPRTRJ0FH50:2025,549300JF6LPRTRJ0FH50,Absolute emission reduction,2014.0,2025,50.0,percent,https://corporate.kohls.com/content/dam/kohlscorp/corporate-responsibility/landing-page/Kohls-ESG%20Report.pdf,net_zero_tracker
+net_zero_tracker:549300JQQA6MQ4OJP259:2030,549300JQQA6MQ4OJP259,Absolute emission reduction,2020.0,2030,42.0,percent,https://mccormick.widen.net/s/x5bmvpfgc7/2021_plp_report,net_zero_tracker
+net_zero_tracker:549300JSX0Z4CW0V5023:2030,549300JSX0Z4CW0V5023,Absolute emission reduction,2017.0,2030,30.0,percent,https://www.adidas-group.com/media/filer_public/a8/5c/a85c9b8e-865b-4237-8def-8574be243577/annual_report_gb-2019_en.pdf,net_zero_tracker
+net_zero_tracker:549300KI75VYLLMSK856:2035,549300KI75VYLLMSK856,Absolute emission reduction,2018.0,2035,50.0,percent,https://www.sse.com/media/q0ilyek3/net-zero-transition-report-final.pdf,net_zero_tracker
+net_zero_tracker:549300KMHPUAQI8VEH90:2030,549300KMHPUAQI8VEH90,Absolute emission reduction,2017.0,2030,40.0,percent,https://www.jpower.co.jp/english/ir/ir51000.html,net_zero_tracker
+net_zero_tracker:549300KP43CPCUJOOG15:2030,549300KP43CPCUJOOG15,Absolute emission reduction,2010.0,2030,60.0,percent,https://www.vistracorp.com/wp-content/uploads/2020/11/VST-2020-Climate-Report.pdf,net_zero_tracker
+net_zero_tracker:549300LBHTST91VKHO68:2030,549300LBHTST91VKHO68,Absolute emission reduction,2019.0,2030,50.0,percent,https://www.toshiba.co.jp/env/en/vision/vision2050_0.htm,net_zero_tracker
+net_zero_tracker:549300LMMRSZZCZ8CL11:2030,549300LMMRSZZCZ8CL11,Absolute emission reduction,2018.0,2030,26.0,percent,https://www.responsibilityreports.com/HostedData/ResponsibilityReports/PDF/NYSE_UNP_2021.pdf,net_zero_tracker
+net_zero_tracker:549300LRIF3NWCU26A80:2030,549300LRIF3NWCU26A80,Absolute emission reduction,2020.0,2030,50.0,percent,https://www.blackrock.com/corporate/investor-relations/blackrock-client-letter,net_zero_tracker
+net_zero_tracker:549300LSGBXPYHXGDT93:2025,549300LSGBXPYHXGDT93,Absolute emission reduction,2019.0,2025,85.0,percent,https://www.wpp.com/-/media/project/wpp/files/sustainability/reports/2021/wpp_sr_2021_interactive-------.pdf?la=en,net_zero_tracker
+net_zero_tracker:549300LTH67W4GWMRF57:2030,549300LTH67W4GWMRF57,Absolute emission reduction,2019.0,2030,30.0,percent,https://www.cocacolaep.com/assets/2021-CCEP-Integrated-Report-and-Form-20-F_v2-v2.pdf,net_zero_tracker
+net_zero_tracker:549300M3VH1A3ER1TB49:2030,549300M3VH1A3ER1TB49,Absolute emission reduction,2016.0,2030,35.0,percent,https://www.essity.com/sustainability/our-journey-to-net-zero/climate-targets/,net_zero_tracker
+net_zero_tracker:549300MMVL80RTBP3O28:2030,549300MMVL80RTBP3O28,Absolute emission reduction,2018.0,2030,30.0,percent,https://www.solvay.com/en/sustainability/climate,net_zero_tracker
+net_zero_tracker:549300MR6PG2DWZUIL39:2025,549300MR6PG2DWZUIL39,Absolute emission reduction,2019.0,2025,15.0,percent,https://www.aramark.com/content/dam/aramark/en/environmental-social-governance/reporting/Aramark-2021-Impact-Report.pdf,net_zero_tracker
+net_zero_tracker:549300N244BVAEE6HH86:2030,549300N244BVAEE6HH86,Absolute emission reduction,2016.0,2030,30.0,percent,https://www.subaru.co.jp/en/csr/subaru_csr/sixpriority/environment.html,net_zero_tracker
+net_zero_tracker:549300NYKK9MWM7GGW15:2030,549300NYKK9MWM7GGW15,Absolute emission reduction,2014.0,2030,90.0,percent,https://www.ing.com/Sustainability/The-world-around-us-1/Reporting.htm,net_zero_tracker
+net_zero_tracker:549300OF70FSEUQBT254:2025,549300OF70FSEUQBT254,Relative emission reduction,2008.0,2025,32.0,percent,https://www.bxp.com/commitment,net_zero_tracker
+net_zero_tracker:549300OJ9VZHZRO6I137:2025,549300OJ9VZHZRO6I137,Absolute emission reduction,2015.0,2025,20.0,percent,https://s23.q4cdn.com/539497486/files/doc_downloads/2022/04/Tractor-Supply-Sustainability-Report-FY2021.pdf,net_zero_tracker
+net_zero_tracker:549300P0R46FF6DUA630:2030,549300P0R46FF6DUA630,Absolute emission reduction,2017.0,2030,0.0,percent,https://sustainability.idemitsu.com/en/themes/311,net_zero_tracker
+net_zero_tracker:549300P7ZYCQJ36CCS16:2020,549300P7ZYCQJ36CCS16,Absolute emission reduction,2000.0,2020,30.0,percent,https://global.honda/content/dam/site/global/about/cq_img/sustainability/report/pdf/2021/Honda-SR-2021-en-all.pdf,net_zero_tracker
+net_zero_tracker:549300PGTHDQY6PSUI61:2030,549300PGTHDQY6PSUI61,Absolute emission reduction,2005.0,2030,70.0,percent,https://investors.evergy.com/news-releases/news-release-details/evergy-sets-goal-net-zero-carbon-emissions-2045-interim-carbon,net_zero_tracker
+net_zero_tracker:549300PW7VPFCYKLIV37:2030,549300PW7VPFCYKLIV37,Absolute emission reduction,2015.0,2030,70.0,percent,https://esg.averydennison.com/en/home/environmental-footprint/ghg-emissions-and-energy-use.html,net_zero_tracker
+net_zero_tracker:549300QD81EPLH4NUQ92:2025,549300QD81EPLH4NUQ92,Absolute emission reduction,2015.0,2025,75.0,percent,https://www.results.philips.com/publications/ar20,net_zero_tracker
+net_zero_tracker:549300QQXOOYEF89IC56:2030,549300QQXOOYEF89IC56,Relative emission reduction,2020.0,2030,50.0,percent,https://www.responsibilityreports.com/HostedData/ResponsibilityReports/PDF/NASDAQ_WDC_2021.pdf,net_zero_tracker
+net_zero_tracker:549300R22LSX6OHWEN64:2024,549300R22LSX6OHWEN64,Relative emission reduction,2019.0,2024,50.0,percent,https://www.diamondbackenergy.com/news-releases/news-release-details/diamondback-energy-inc-announces-fourth-quarter-and-full-year-1,net_zero_tracker
+net_zero_tracker:549300RPTUOIXG4LIH86:2020,549300RPTUOIXG4LIH86,Relative emission reduction,2011.0,2020,20.0,percent,https://www.walgreensbootsalliance.com/sites/www/files/2021-01/WBA_CDP_Climate_Change_Questionnaire_2020_26%20Aug.pdf,net_zero_tracker
+net_zero_tracker:549300S9XF92D1X8ME43:2030,549300S9XF92D1X8ME43,Absolute emission reduction,2016.0,2030,30.0,percent,https://www.angloamerican.com/~/media/Files/A/Anglo-American-Group/PLC/investors/annual-reporting/2022/aa-sustainability-report-full-2021.pdf,net_zero_tracker
+net_zero_tracker:549300SQYI82RVWFN715:2030,549300SQYI82RVWFN715,Absolute emission reduction,2011.0,2030,60.0,percent,https://responsibility.metroag.de/focus-areas/climate-action,net_zero_tracker
+net_zero_tracker:549300SVYJS666PQJH88:2030,549300SVYJS666PQJH88,Absolute emission reduction,2019.0,2030,30.0,percent,https://www.firstenergycorp.com/newsroom/news_articles/firstenergy-pledges-to-achieve-carbon-neutrality-by-2050.html,net_zero_tracker
+net_zero_tracker:549300T6IPOCDWLKC615:2030,549300T6IPOCDWLKC615,Absolute emission reduction,2010.0,2030,50.0,percent,https://sustainability.hitachi.com/wp-content/uploads/2021/10/en_sustainability2021_full.pdf,net_zero_tracker
+net_zero_tracker:549300TRXM9Y6561AX39:2030,549300TRXM9Y6561AX39,Absolute emission reduction,2017.0,2030,18.0,percent,https://www.mitsubishielectric.com/en/sustainability/reports/pdf/2021/Sustainability_report_2021_all.pdf,net_zero_tracker
+net_zero_tracker:549300TTCXZOGZM2EY83:2030,549300TTCXZOGZM2EY83,Absolute emission reduction,2018.0,2030,90.0,percent,https://www.inditex.com/our-commitment-to-the-environment/climate-change-and-energy,net_zero_tracker
+net_zero_tracker:549300U41AUUVOAAOB37:2025,549300U41AUUVOAAOB37,Absolute emission reduction,2015.0,2025,38.0,percent,https://www.roche.com/sustainability/environment/our_she_goals_and_performance.htm,net_zero_tracker
+net_zero_tracker:549300UDG16DOYUPR330:2030,549300UDG16DOYUPR330,Absolute emission reduction,2018.0,2030,30.0,percent,https://ucpcdn.thyssenkrupp.com/_binary/UCPthyssenkruppAG/en/investors/presentations-and-events/capital-market-days/berichterstattung-und-publikationen-kopie/link-thyssenkrupp-GB-2019-2020-EN-Web.pdf,net_zero_tracker
+net_zero_tracker:549300UINV5RINHGMG07:2030,549300UINV5RINHGMG07,Absolute emission reduction,2015.0,2030,70.0,percent,https://group.skanska.com/4938df/siteassets/investors/reports-publications/annual-reports/2021/annual-and-sustainability-report-2021.pdf,net_zero_tracker
+net_zero_tracker:549300UPNBTXA1SYTQ33:2030,549300UPNBTXA1SYTQ33,Absolute emission reduction,2019.0,2030,50.0,percent,https://assets.website-files.com/6019e43dcfad3c059841794a/60a6d3d36ca419aff05b0371_2020%20Sustainability%20Report%20052021-min.pdf,net_zero_tracker
+net_zero_tracker:549300V62YJ9HTLRI486:2040,549300V62YJ9HTLRI486,Relative emission reduction,2019.0,2040,50.0,percent,https://reports.omv.com/en/sustainability-report/2021/servicepages/downloads/files/entire-omv-sr21.pdf,net_zero_tracker
+net_zero_tracker:549300VIWYMSIGT1U456:2030,549300VIWYMSIGT1U456,Absolute emission reduction,2019.0,2030,50.0,percent,https://www.cigna.com/about-us/corporate-responsibility/report/environment/sustainability-performance-plan,net_zero_tracker
+net_zero_tracker:549300VSP3RIX7FGDZ51:2030,549300VSP3RIX7FGDZ51,Absolute emission reduction,2018.0,2030,32.0,percent,https://s24.q4cdn.com/382246808/files/doc_downloads/sustainability/2021-report/newmont-2021-sustainability-report.pdf,net_zero_tracker
+net_zero_tracker:549300VZCL1HTH4O4Y49:2025,549300VZCL1HTH4O4Y49,Absolute emission reduction,2010.0,2025,65.0,percent,https://www.henkel.com/spotlight/features/climate-action,net_zero_tracker
+net_zero_tracker:549300WSX3VBUFFJOO66:2025,549300WSX3VBUFFJOO66,Absolute emission reduction,2015.0,2025,46.0,percent,https://www.relx.com/media/press-releases/year-2021/net-zero,net_zero_tracker
+net_zero_tracker:549300WTZWR07K8MNV44:2030,549300WTZWR07K8MNV44,Absolute emission reduction,2019.0,2030,46.0,percent,https://www.gilead.com/-/media/files/pdfs/yir-2021-pdfs/2021-gilead-yir_desktop.pdf?la=en&hash=5435F68EB8113745A8756DB75947E7B4,net_zero_tracker
+net_zero_tracker:549300WZN9I2QKLS0O94:2030,549300WZN9I2QKLS0O94,Relative emission reduction,2020.0,2030,65.0,percent,https://www.corteva.com/content/dam/dpagco/corteva/global/corporate/files/sustainability/DOC-CORTEVA_2020_SUSTAINABILITY_REPORT_v2-Global.pdf,net_zero_tracker
+net_zero_tracker:549300X2937PB0CJ7I56:2028,549300X2937PB0CJ7I56,Absolute emission reduction,2021.0,2028,30.0,percent,https://www.corning.com/media/worldwide/global/documents/2021_Sustainability_Report_Corning_Incorporated.pdf,net_zero_tracker
+net_zero_tracker:549300X3UK4GG3FNMO06:2030,549300X3UK4GG3FNMO06,Absolute emission reduction,2017.0,2030,50.0,percent,https://www.edf.fr/en/the-edf-group/taking-action-as-a-responsible-company/reports-and-indicators/2021-impact-report,net_zero_tracker
+net_zero_tracker:549300XMP3KDCKJXIU47:2030,549300XMP3KDCKJXIU47,Absolute emission reduction,2019.0,2030,50.0,percent,https://www.marshmclennan.com/content/dam/mmc-web/v3/esg/Marsh-McLennan-2021-ESG-Report-FINAL.pdf,net_zero_tracker
+net_zero_tracker:549300XTO5VR8SKV1V74:2025,549300XTO5VR8SKV1V74,Absolute emission reduction,2011.0,2025,63.0,percent,https://www.valero.com/sites/default/files/valero-documents/2020%20SRR_Web%20Version_Spreads%207-26.pdf,net_zero_tracker
+net_zero_tracker:549300YECS8HKCIMMB67:2030,549300YECS8HKCIMMB67,Absolute emission reduction,2020.0,2030,50.0,percent,https://www.assaabloy.com/group/en/news-media/press-releases/id.CFA9811B900E9B83,net_zero_tracker
+net_zero_tracker:549300YX8JIID70NFS41:2032,549300YX8JIID70NFS41,Absolute emission reduction,2021.0,2032,42.0,percent,https://sustainability.wm.com/downloads/WM_2022_SR.pdf,net_zero_tracker
+net_zero_tracker:549300Z40J86GGSTL398:2030,549300Z40J86GGSTL398,Absolute emission reduction,2015.0,2030,63.0,percent,https://about.att.com/csr/home/reporting/issue-brief/climate-change.html,net_zero_tracker
+net_zero_tracker:549300ZFEEJ2IP5VME73:2030,549300ZFEEJ2IP5VME73,Absolute emission reduction,2019.0,2030,27.0,percent,https://www.statestreet.com/content/dam/statestreet/documents/values/state-street-esg-report-04-2021.pdf,net_zero_tracker
+net_zero_tracker:549300ZHW0TR2QZ0NY83:2030,549300ZHW0TR2QZ0NY83,Absolute emission reduction,2016.0,2030,32.0,percent,https://sustainability.omron.com/en/environ/climate_change/response/#Anchor-pageLink02,net_zero_tracker
+net_zero_tracker:549300ZLMVP4X0OGR454:2025,549300ZLMVP4X0OGR454,Absolute emission reduction,2016.0,2025,40.0,percent,https://www.takeda.com/49f45f/siteassets/system/corporate-responsibility/reporting-on-sustainability/tcfd.pdf,net_zero_tracker
+net_zero_tracker:5E2UPK5SW04M13XY7I38:2025,5E2UPK5SW04M13XY7I38,Absolute emission reduction,2014.0,2025,50.0,percent,https://www.nrg.com/assets/documents/sustainability/2021-sustainability-report.pdf,net_zero_tracker
+net_zero_tracker:6EY4K7ZMF9UX1CU6KC79:2025,6EY4K7ZMF9UX1CU6KC79,Absolute emission reduction,2015.0,2025,25.0,percent,https://www.xilinx.com/content/dam/xilinx/publications/about/xilinx-cdp-climate-change-2021.pdf,net_zero_tracker
+net_zero_tracker:6SYKCME112RT8TQUO411:2034,6SYKCME112RT8TQUO411,Absolute emission reduction,2018.0,2034,68.0,percent,https://www.jll.co.uk/content/dam/jll-com/documents/pdf/other/jll-global-sustainability-full-report-2020.pdf,net_zero_tracker
+net_zero_tracker:724500K5PTPSST86UQ23:2030,724500K5PTPSST86UQ23,Absolute emission reduction,2018.0,2030,90.0,percent,https://www.theheinekencompany.com/sites/theheinekencompany/files/Downloads/PDF/sustainability%20and%20responsibility/heineken-on-the-path-to-net-zero-2021.pdf?_ga=2.145104438.301010175.1647426557-347249191.1647426557,net_zero_tracker
+net_zero_tracker:724500OHYNDT9OY6Q215:2025,724500OHYNDT9OY6Q215,Absolute emission reduction,2019.0,2025,25.0,percent,https://www.nn-group.com/nn-group/file?uuid=fe0ed772-850a-4697-95e5-06a1fe376e0f&owner=84c25534-c28a-4a64-9c78-5cc1388e4766&contentid=11805,net_zero_tracker
+net_zero_tracker:724500SNT1MK246AHP04:2030,724500SNT1MK246AHP04,Absolute emission reduction,2016.0,2030,50.0,percent,https://www.dsm.com/corporate/sustainability/climate-energy/improving-our-carbon-footprint.html,net_zero_tracker
+net_zero_tracker:724500XYIJUGXAA5QD70:2030,724500XYIJUGXAA5QD70,Absolute emission reduction,2020.0,2030,42.0,percent,https://www.akzonobel.com/en/about-us/position-statements/climate-change,net_zero_tracker
+net_zero_tracker:7890005U0H950VH19H45:2030,7890005U0H950VH19H45,Absolute emission reduction,2013.0,2030,30.0,percent,https://www.kobelco.co.jp/english/about_kobelco/outline/integrated-reports/files/integrated-reports2021_e.pdf,net_zero_tracker
+net_zero_tracker:7CUNS533WID6K7DGFI87:2024,7CUNS533WID6K7DGFI87,Absolute emission reduction,2021.0,2024,19.0,percent,https://www.caixabank.com/deployedfiles/caixabank_com/Estaticos/PDFs/Accionistasinversores/Informacion_economico_financiera/IGC_30062022_ING.pdf,net_zero_tracker
+net_zero_tracker:815600354DEDBD0BA991:2025,815600354DEDBD0BA991,Absolute emission reduction,2020.0,2025,30.0,percent,https://www.annualreports.com/HostedData/AnnualReports/PDF/poste-italiane_2021.pdf,net_zero_tracker
+net_zero_tracker:82DYEISM090VG8LTLS26:2030,82DYEISM090VG8LTLS26,Absolute emission reduction,2018.0,2030,50.0,percent,https://en-uk.ecolab.com/corporate-responsibility/2030-impact-goals,net_zero_tracker
+net_zero_tracker:851WYGNLUQLFZBSYGB56:2025,851WYGNLUQLFZBSYGB56,Absolute emission reduction,2018.0,2025,30.0,percent,https://www.commerzbank.de/en/nachhaltigkeit/gesellschaft/klimastrategie/standardseitenvorlage_3.html,net_zero_tracker
+net_zero_tracker:894500ZRIX9K13RHXR17:2025,894500ZRIX9K13RHXR17,Absolute emission reduction,2019.0,2025,18.0,percent,https://www.te.com/usa-en/about-te/corporate-responsibility.html,net_zero_tracker
+net_zero_tracker:8I5DZWZKVSZI1NUHU748:2030,8I5DZWZKVSZI1NUHU748,Absolute emission reduction,2017.0,2030,40.0,percent,https://www.jpmorganchase.com/content/dam/jpmc/jpmorgan-chase-and-co/documents/jpmc-esg-report-2020.pdf,net_zero_tracker
+net_zero_tracker:8R95QZMKZLJX5Q2XR704:2030,8R95QZMKZLJX5Q2XR704,Absolute emission reduction,1990.0,2030,80.0,percent,https://www.nationalgrid.com/stories/journey-to-net-zero/national-grids-net-zero-commitment,net_zero_tracker
+net_zero_tracker:8WDDFXB5T1Z6J0XC1L66:2030,8WDDFXB5T1Z6J0XC1L66,Absolute emission reduction,2017.0,2030,32.0,percent,https://corporate.target.com/corporate-responsibility/planet/climate,net_zero_tracker
+net_zero_tracker:95980020140005007414:2030,95980020140005007414,Absolute emission reduction,2015.0,2030,75.0,percent,https://www.inmocolonial.com/sites/default/files/69792_colonial_2020_web_eng.pdf,net_zero_tracker
+net_zero_tracker:9598004A3FTY3TEHHN09:2030,9598004A3FTY3TEHHN09,Absolute emission reduction,2015.0,2030,100.0,percent,https://corporate.amadeus.com/documents/en/resources/corporate-information/corporate-documents/global-reports/2020/amadeus-global-report-2020.pdf,net_zero_tracker
+net_zero_tracker:959800HSSNXWRKBK4N60:2030,959800HSSNXWRKBK4N60,Absolute emission reduction,2021.0,2030,55.0,percent,https://www.grifols.com/documents/3625622/3683813/sustainability-report-2021-en.pdf/9588cf72-d301-5beb-da48-ff3469851746?t=1647279808393,net_zero_tracker
+net_zero_tracker:9695003E4MMA10IBTR26:2030,9695003E4MMA10IBTR26,Absolute emission reduction,2030.0,2030,60.0,percent,https://www.gecina.fr/sites/default/files/2019-04/rapportclimat_gb_240716_1225.pdf,net_zero_tracker
+net_zero_tracker:969500A1YF1XUYYXS284:2030,969500A1YF1XUYYXS284,Absolute emission reduction,2017.0,2030,35.0,percent,https://www.se.com/ww/en/assets/564/document/322964/sustainability-report-2021.pdf,net_zero_tracker
+net_zero_tracker:969500AQW31GYO8JZD66:2030,969500AQW31GYO8JZD66,Absolute emission reduction,2019.0,2030,12.0,percent,https://corporate.airfrance.com/en/news/air-france-launches-its-air-france-act-programme-presenting-its-new-co2-emissions-reduction,net_zero_tracker
+net_zero_tracker:969500F7JLTX36OUI695:2030,969500F7JLTX36OUI695,Absolute emission reduction,2019.0,2030,50.0,percent,https://www.renaultgroup.com/wp-content/uploads/2021/04/220421_climate-report-renault-group_8mb.pdf,net_zero_tracker
+net_zero_tracker:969500LCBOG12HXPYM84:2025,969500LCBOG12HXPYM84,Absolute emission reduction,2017.0,2025,34.0,percent,https://www.sodexo.com/files/live/sites/com-global/files/02%20PDF/Finance/Sodexo-Integrated-Report-Fiscal-2020.pdf,net_zero_tracker
+net_zero_tracker:969500LENY69X51OOT31:2040,969500LENY69X51OOT31,Absolute emission reduction,2020.0,2040,100.0,percent,https://netzero.veolia.co.uk/our-commitments-and-road-map-uk-and-ireland/,net_zero_tracker
+net_zero_tracker:969500MCOONR8990S771:2025,969500MCOONR8990S771,Absolute emission reduction,2015.0,2025,30.0,percent,https://www.orange.com/en/environmental-commitment-orange-vows-achieve-net-zero-carbon-emissions-2040,net_zero_tracker
+net_zero_tracker:969500MMPQVHK671GT54:2035,969500MMPQVHK671GT54,Absolute emission reduction,2018.0,2035,33.0,percent,https://www.airliquide.com/sites/airliquide.com/files/2021/03/22/act-leaflet.pdf,net_zero_tracker
+net_zero_tracker:969500P8M3W2XX376054:2030,969500P8M3W2XX376054,Absolute emission reduction,2010.0,2030,40.0,percent,https://www.covivio.eu/en/wp-content/uploads/sites/3/2021/11/PR-Carbon-trajectory.pdf,net_zero_tracker
+net_zero_tracker:969500PB4U31KEFHZ621:2022,969500PB4U31KEFHZ621,Absolute emission reduction,2010.0,2022,40.0,percent,https://www.klepierre.com/en/finance/2020-universal-registration-document,net_zero_tracker
+net_zero_tracker:969500UIC89GT3UL7L24:2030,969500UIC89GT3UL7L24,Absolute emission reduction,2018.0,2030,50.0,percent,https://ungc-production.s3.us-west-2.amazonaws.com/attachments/cop_2020/487926/original/2019_SAFRAN__Integrated_Report.pdf?1596528297,net_zero_tracker
+net_zero_tracker:969500WP61NBK098AC47:2030,969500WP61NBK098AC47,Relative emission reduction,2016.0,2030,60.0,percent,https://www.groupeseb.com/en/climate-action,net_zero_tracker
+net_zero_tracker:969500XXRPGD7HCAFA90:2030,969500XXRPGD7HCAFA90,Absolute emission reduction,2016.0,2030,30.0,percent,https://www.legrandgroup.com/sites/default/files/Documents_PDF_Legrand/Finance/2021/autres/Legrand_URD_2020_1620039999.pdf,net_zero_tracker
+net_zero_tracker:9N3UAJSNOUXFKQLF3V18:2035,9N3UAJSNOUXFKQLF3V18,Absolute emission reduction,2010.0,2035,70.0,percent,https://pplweb.mediaroom.com/2021-08-05-PPL-Corporation-Reports-Second-Quarter-2021-Earnings-Announces-Net-Zero-Carbon-Emissions-Goal,net_zero_tracker
+net_zero_tracker:9ZHRYM6F437SQJ6OUG95:2030,9ZHRYM6F437SQJ6OUG95,Absolute emission reduction,2011.0,2030,40.0,percent,https://www.rbinternational.com/resources/RBI/raiffeisen-bank-international/sustainability/sustainability-report/RBI-Sustainability-Report-2020-EN-barrier-free-optimized.pdf,net_zero_tracker
+net_zero_tracker:AR5L2ODV9HN37376R084:2025,AR5L2ODV9HN37376R084,Absolute emission reduction,2016.0,2025,58.0,percent,https://www.mastercard.com/news/press/2021/january/mastercard-pledges-net-zero-emissions-innovates-for-collective-climate-action/,net_zero_tracker
+net_zero_tracker:BSYCX13Y0NOTV14V9N85:2040,BSYCX13Y0NOTV14V9N85,Absolute emission reduction,2016.0,2040,55.0,percent,https://www.repsol.com/content/dam/repsol-corporate/en_gb/accionistas-e-inversores/informes-anuales/2021/integrated-management-report-2021.pdf,net_zero_tracker
+net_zero_tracker:BUCRF72VH5RBN7X3VL35:2030,BUCRF72VH5RBN7X3VL35,Relative emission reduction,2000.0,2030,50.0,percent,https://www.entergy.com/environment/,net_zero_tracker
+net_zero_tracker:C4BXATY60WC6XEOZDX54:2030,C4BXATY60WC6XEOZDX54,Absolute emission reduction,2019.0,2030,30.0,percent,https://sustainabilityreport.metlife.com/content/dam/metlifecom/us/sustainability/pdf/report/2020/2020-sustainability-report.pdf,net_zero_tracker
+net_zero_tracker:CFGNEKW0P8842LEUIA51:2025,CFGNEKW0P8842LEUIA51,Absolute emission reduction,2009.0,2025,75.0,percent,https://www.pnc.com/content/dam/pnc-com/pdf/aboutpnc/CorporateResponsibilityReports/PNC_Corporate_Responsibility_Report_2021.pdf,net_zero_tracker
+net_zero_tracker:CUMYEZJOAF02RYZ1JJ85:2035,CUMYEZJOAF02RYZ1JJ85,Absolute emission reduction,2020.0,2035,40.0,percent,https://secure02.principal.com/publicvsupply/GetFile?fm=EE12496&ty=VOP,net_zero_tracker
+net_zero_tracker:CWAJJ9DJ5Z7P057HV541:2030,CWAJJ9DJ5Z7P057HV541,Absolute emission reduction,2017.0,2030,55.0,percent,https://www.vfc.com/sustainability-and-responsibility/climate,net_zero_tracker
+net_zero_tracker:CZ72ZHBVKZXQRV3XFE26:2021,CZ72ZHBVKZXQRV3XFE26,Absolute emission reduction,2019.0,2021,20.0,percent,https://sustainability.ovintiv.com/environment/emissions-and-climate-change/,net_zero_tracker
+net_zero_tracker:CZ72ZHBVKZXQRV3XFE26:2030,CZ72ZHBVKZXQRV3XFE26,Absolute emission reduction,2017.0,2030,20.0,percent,https://www.otsuka.com/en/csr/environment/climate.html,net_zero_tracker
+net_zero_tracker:D01LMJZU09ULLNCY6Z23:2035,D01LMJZU09ULLNCY6Z23,Absolute emission reduction,2020.0,2035,30.0,percent,https://www.edie.net/news/6/UPS-aims-for-carbon-neutral-by-2050/,net_zero_tracker
+net_zero_tracker:D71FAKCBLFS2O0RBPG08:2030,D71FAKCBLFS2O0RBPG08,Absolute emission reduction,2005.0,2030,56.0,percent,https://investor.williams.com/press-releases/press-release-details/2020/Williams-Announces-Goal-of-56-Absolute-Reduction-in-Greenhouse-Gas-Emissions-by-2030/default.aspx,net_zero_tracker
+net_zero_tracker:DX6GCWD4Q1JO9CRE5I40:2025,DX6GCWD4Q1JO9CRE5I40,Absolute emission reduction,2020.0,2025,55.0,percent,https://ugiesg.com/environment/,net_zero_tracker
+net_zero_tracker:E0JAN6VLUDI1HITHT809:2035,E0JAN6VLUDI1HITHT809,Absolute emission reduction,2016.0,2035,40.0,percent,https://www.chubb.com/content/dam/chubb-sites/chubb-com/us-en/about-chubb/environment/doc/Chubb_2021_Climate-Related_Financial_Disclosure_and_Environmental_Report.pdf,net_zero_tracker
+net_zero_tracker:F5WCUMTUM4RKZ1MAIE39:2030,F5WCUMTUM4RKZ1MAIE39,Absolute emission reduction,2010.0,2030,40.0,percent,https://www-axa-com.cdn.axa-contento-118412.eu/www-axa-com/7c51bab4-4266-42b6-aa8a-a6b209ee6e33_2019ClimateStrategy.pdf,net_zero_tracker
+net_zero_tracker:F8SB4JFBSYQFRQEH3Z21:2025,F8SB4JFBSYQFRQEH3Z21,Absolute emission reduction,2019.0,2025,51.0,percent,https://www.nab.com.au/about-us/social-impact/environment/climate-change,net_zero_tracker
+net_zero_tracker:FCNMH6O7VWU7LHXMK351:2025,FCNMH6O7VWU7LHXMK351,Relative emission reduction,2005.0,2025,20.0,percent,https://www.cabotcorp.com/-/media/files/reports/responsibility/cabot-corporation-sustainability-report-2021.pdf?la=en&rev=f75baea27ba94c0b8f6cae54ab91f2df,net_zero_tracker
+net_zero_tracker:FDPVHDGJ1IQZFK9KH630:2030,FDPVHDGJ1IQZFK9KH630,Absolute emission reduction,2017.0,2030,33.0,percent,https://www.eastman.com/Company/Sustainability/Documents/Eastman-Sustainability-Report-2020.pdf,net_zero_tracker
+net_zero_tracker:FGLT0EWZSUIRRITFOA30:2030,FGLT0EWZSUIRRITFOA30,Absolute emission reduction,2021.0,2030,25.0,percent,https://www.emerson.com/documents/corporate/emerson-2021-environmental-social-governance-report-en-us-8186672.pdf,net_zero_tracker
+net_zero_tracker:FJSUNZKFNQ5YPJ5OT455:2030,FJSUNZKFNQ5YPJ5OT455,Absolute emission reduction,2015.0,2030,75.0,percent,https://www.pepsico.com/our-impact/esg-topics-a-z/climate-change,net_zero_tracker
+net_zero_tracker:FR5LCKFTG8054YNNRU85:2025,FR5LCKFTG8054YNNRU85,Absolute emission reduction,2015.0,2025,25.0,percent,https://www.abbvie.com/content/dam/abbvie-dotcom/uploads/PDFs/AbbVie-Environmental_Stewardship-9.2016.pdf,net_zero_tracker
+net_zero_tracker:FXM8FAOHMYDIPD38UZ17:2030,FXM8FAOHMYDIPD38UZ17,Absolute emission reduction,2019.0,2030,95.0,percent,https://www.bookingholdings.com/wp-content/uploads/2022/03/BKNG-Sustainability-Report-2021.pdf,net_zero_tracker
+net_zero_tracker:GYVOE5EZ4GDAVTU4CQ61:2025,GYVOE5EZ4GDAVTU4CQ61,Absolute emission reduction,2015.0,2025,50.0,percent,https://www.analog.com/media/en/company-csr/adi-2020-corporate-responsibility-report.pdf,net_zero_tracker
+net_zero_tracker:HCHV7422L5HDJZCRFL38:2030,HCHV7422L5HDJZCRFL38,Absolute emission reduction,2020.0,2030,30.0,percent,https://thermofisher.mediaroom.com/2021-07-27-Thermo-Fisher-Scientific-Commits-to-Achieve-Net-Zero-Carbon-Emissions-by-2050,net_zero_tracker
+net_zero_tracker:HL3H1H2BGXWVG3BSWR90:2030,HL3H1H2BGXWVG3BSWR90,Absolute emission reduction,2019.0,2030,50.0,percent,https://www.pmi.com/sustainability/our-2025-roadmap,net_zero_tracker
+net_zero_tracker:HL5XPTVRV0O8TUN5LL90:2030,HL5XPTVRV0O8TUN5LL90,Absolute emission reduction,2000.0,2030,20.0,percent,https://corporate.bestbuy.com/best-buy-signs-the-climate-pledge-accelerating-sustainability-goals/,net_zero_tracker
+net_zero_tracker:HO1QNWM0IXBZ0QSMMO20:2030,HO1QNWM0IXBZ0QSMMO20,Absolute emission reduction,2020.0,2030,30.0,percent,https://corporate.ralphlauren.com/on/demandware.static/-/Sites-RalphLauren_Corporate-Library/default/dw7119005d/documents/2022-RL-GCSReport.pdf,net_zero_tracker
+net_zero_tracker:HV5W8PGLJ127N2SFSM23:2025,HV5W8PGLJ127N2SFSM23,Absolute emission reduction,2010.0,2025,20.0,percent,https://www.bkb.ch/de/-/media/bkb/website/pdf/berichte-und-praesentationen/bkb-strategie-2022plus.pdf,net_zero_tracker
+net_zero_tracker:I07WOS4YJ0N7YRFE7309:2030,I07WOS4YJ0N7YRFE7309,Absolute emission reduction,2019.0,2030,46.0,percent,https://investors.rtx.com/static-files/56ac9c22-51b0-43e4-a12e-842f9fdcf3fa,net_zero_tracker
+net_zero_tracker:I1BZKREC126H0VB1BL91:2030,I1BZKREC126H0VB1BL91,Absolute emission reduction,2005.0,2030,50.0,percent,https://www.duke-energy.com/our-company/esg/esg-report,net_zero_tracker
+net_zero_tracker:I9Q57JVPWHHZ3ZGBW498:2030,I9Q57JVPWHHZ3ZGBW498,Absolute emission reduction,2012.0,2030,65.0,percent,https://www.comerica.com/content/dam/comerica/en/documents/resources/about/sustainability/2020-comerica-cr-report-final.pdf,net_zero_tracker
+net_zero_tracker:ICE2EP6D98PQUILVRZ91:2030,ICE2EP6D98PQUILVRZ91,Absolute emission reduction,2019.0,2030,46.0,percent,https://investors.bd.com/static-files/3cd64f37-762a-4aa7-bd81-9b9030172dee,net_zero_tracker
+net_zero_tracker:IGJSJL3JD5P30I6NJZ34:2022,IGJSJL3JD5P30I6NJZ34,Absolute emission reduction,2012.0,2022,100.0,percent,https://www.morganstanley.com/ideas/climate-change-net-zero-financed-emissions,net_zero_tracker
+net_zero_tracker:ILUL7B6Z54MRYCF6H308:2030,ILUL7B6Z54MRYCF6H308,Absolute emission reduction,2010.0,2030,65.0,percent,https://news.dominionenergy.com/2022-02-11-Dominion-Energy-Broadens-Net-Zero-Commitments,net_zero_tracker
+net_zero_tracker:IOG4E947OATN0KJYSD45:2026,IOG4E947OATN0KJYSD45,Absolute emission reduction,2019.0,2026,50.0,percent,https://r.lvmh-static.com/uploads/2021/05/life_360_en_externe_def.pdf,net_zero_tracker
+net_zero_tracker:ISRPG12PN4EIEOEMW547:2024,ISRPG12PN4EIEOEMW547,Absolute emission reduction,2018.0,2024,10.0,percent,https://www.honeywell.com/content/dam/honeywellbt/en/documents/downloads/Hon-Corporate-Citizenship-Report.pdf,net_zero_tracker
+net_zero_tracker:IWUQB36BXD6OWD6X4T14:2035,IWUQB36BXD6OWD6X4T14,Absolute emission reduction,2019.0,2035,40.0,percent,https://www.aa.com/content/images/customer-service/about-us/corporate-governance/esg/aag-esg-report-2021.pdf,net_zero_tracker
+net_zero_tracker:J3WHBG0MTS7O8ZVMDC91:2030,J3WHBG0MTS7O8ZVMDC91,Absolute emission reduction,2016.0,2030,20.0,percent,https://corporate.exxonmobil.com/-/media/Global/Files/Advancing-Climate-Solutions-Progress-Report/2022/ExxonMobil-Advancing-Climate-Solutions-2022-Progress-Report.pdf?la=en&hash=AFC42B15F21ADB081F9A35AA685385A3287F48E5,net_zero_tracker
+net_zero_tracker:J48DJYXDTLHM30UMYI18:2030,J48DJYXDTLHM30UMYI18,Absolute emission reduction,2018.0,2030,40.0,percent,https://www.itochu.co.jp/en/csr/pdf/21fulle-all.pdf,net_zero_tracker
+net_zero_tracker:J5OIVXX3P24RJRW5CK77:2030,J5OIVXX3P24RJRW5CK77,Absolute emission reduction,2020.0,2030,25.0,percent,https://www.baxter.com/sites/g/files/ebysai3896/files/2022-06/Baxter_2021_Corporate_Responsibility_Report.pdf,net_zero_tracker
+net_zero_tracker:JNLUVFYJT1OZSIQ24U47:2030,JNLUVFYJT1OZSIQ24U47,Absolute emission reduction,2019.0,2030,20.0,percent,https://www.ussteel.com/media/newsroom/-/blogs/united-states-steel-corporation-announces-goal-to-achieve-carbon-neutrality-by-2050,net_zero_tracker
+net_zero_tracker:KVIPTY4PULAPGC1VVD26:2030,KVIPTY4PULAPGC1VVD26,Absolute emission reduction,2020.0,2030,50.0,percent,https://mitsubishicorp.disclosure.site/en/themes/113#917,net_zero_tracker
+net_zero_tracker:KY37LUS27QQX7BB93L28:2030,KY37LUS27QQX7BB93L28,Absolute emission reduction,2018.0,2030,50.0,percent,https://www.nestle.com/sites/default/files/2022-03/2021-annual-review-en.pdf,net_zero_tracker
+net_zero_tracker:L47NHHI0Z9X22DV46U41:2025,L47NHHI0Z9X22DV46U41,Absolute emission reduction,2018.0,2025,30.0,percent,https://www.beiersdorf.com/newsroom/press-releases/all-press-releases/2019/12/17-beiersdorf-implements-ambitious-climate-target,net_zero_tracker
+net_zero_tracker:LAXUQCHT4FH58LRZDY46:2030,LAXUQCHT4FH58LRZDY46,Absolute emission reduction,2018.0,2030,25.0,percent,https://www.eni.com/en-IT/low-carbon/strategy-climate-change.html,net_zero_tracker
+net_zero_tracker:LGJNMI9GH8XIDG5RCM61:2030,LGJNMI9GH8XIDG5RCM61,Absolute emission reduction,2005.0,2030,80.0,percent,https://www.xcelenergy.com/staticfiles/xe-responsive/Company/Sustainability%20Report/2021%20SR/2021-Sustainability-Report-Full.pdf,net_zero_tracker
+net_zero_tracker:LONOZNOJYIBXOHXWDB86:2030,LONOZNOJYIBXOHXWDB86,Absolute emission reduction,2015.0,2030,45.0,percent,https://betterdays.kelloggcompany.com/climate-action,net_zero_tracker
+net_zero_tracker:LUZQVYP4VS22CLWDAR65:2030,LUZQVYP4VS22CLWDAR65,Absolute emission reduction,2019.0,2030,50.0,percent,https://multimedia.3m.com/mws/media/2006067O/3m-sustainability-2021-brochure.pdf,net_zero_tracker
+net_zero_tracker:LZ2C6E0W5W7LQMX5ZI37:2020,LZ2C6E0W5W7LQMX5ZI37,Relative emission reduction,1990.0,2020,23.0,percent,https://www.heidelbergcement.com/de/energie-und-klimaschutz,net_zero_tracker
+net_zero_tracker:M1YXUUZR0EIMU8T0EM75:2025,M1YXUUZR0EIMU8T0EM75,Absolute emission reduction,2015.0,2025,100.0,percent,https://www.astrazeneca.com/content/dam/az/Investor_Relations/annual-report-2021/pdf/AstraZeneca_AR_2021.pdf,net_zero_tracker
+net_zero_tracker:M312WZV08Y7LYUC71685:2030,M312WZV08Y7LYUC71685,Absolute emission reduction,2019.0,2030,60.0,percent,https://www.swedbank.com/sustainability/environment/climate.html,net_zero_tracker
+net_zero_tracker:MP3J6QPYPGN75NVW2S34:2021,MP3J6QPYPGN75NVW2S34,Absolute emission reduction,2015.0,2021,40.0,percent,https://www.kimberly-clark.com/en-us/esg/downloads,net_zero_tracker
+net_zero_tracker:MSFSBD3QN1GSN7Q6C537:2030,MSFSBD3QN1GSN7Q6C537,Absolute emission reduction,2020.0,2030,42.0,percent,https://www.commbank.com.au/content/dam/commbank-assets/about-us/2021-08/2021-annual-report_spreads.pdf#page=12,net_zero_tracker
+net_zero_tracker:MZK1AT00SJV4XB7WNL71:2030,MZK1AT00SJV4XB7WNL71,Absolute emission reduction,2019.0,2030,46.0,percent,https://www.merck.com/wp-content/uploads/sites/5/2021/09/Merck-ESG-Report.pdf,net_zero_tracker
+net_zero_tracker:N1GZ7BBF3NP8GI976H15:2029,N1GZ7BBF3NP8GI976H15,Absolute emission reduction,2014.0,2029,40.0,percent,https://www.usbank.com/about-us-bank/community/sustainability.html,net_zero_tracker
+net_zero_tracker:NFONVGN05Z0FMN5PEC35:2030,NFONVGN05Z0FMN5PEC35,Absolute emission reduction,2017.0,2030,33.0,percent,https://www.saint-gobain.com/sites/saint-gobain.com/files/media/document/2021-06/universal.pdf,net_zero_tracker
+net_zero_tracker:NNROIXVWJ7CPSR27SV97:2020,NNROIXVWJ7CPSR27SV97,Relative emission reduction,2016.0,2020,6.0,percent,,net_zero_tracker
+net_zero_tracker:OQSJ1DU9TAOC51A47K68:2030,OQSJ1DU9TAOC51A47K68,Absolute emission reduction,2019.0,2030,50.0,percent,https://stories.starbucks.com/uploads/2022/04/Starbucks-2021-Global-Environmental-and-Social-Impact-Report-1.pdf,net_zero_tracker
+net_zero_tracker:PBBKGKLRK5S5C0Y4T545:2030,PBBKGKLRK5S5C0Y4T545,Absolute emission reduction,2019.0,2030,50.0,percent,https://www.sempra.com/sites/default/files/content/files/node-report/2020/SempraEnergy_2020_Corporate-Sustainability-Report.pdf,net_zero_tracker
+net_zero_tracker:PY6ZZQWO2IZFZC3IOL08:2025,PY6ZZQWO2IZFZC3IOL08,Absolute emission reduction,2015.0,2025,100.0,percent,https://www.astrazeneca.com/content/dam/az/Sustainability/2021/pdf/Sustainability_Report_2020.pdf,net_zero_tracker
+net_zero_tracker:Q9MAIUP40P25UFBFG033:2030,Q9MAIUP40P25UFBFG033,Absolute emission reduction,2019.0,2030,75.0,percent,https://www.eon.com/content/dam/eon/eon-com/eon-com-assets/documents/sustainability/en/climate-related-disclosures/EON_2022_On_course_for_net_zero.pdf,net_zero_tracker
+net_zero_tracker:QEKMOTMBBKA8I816DO57:2030,QEKMOTMBBKA8I816DO57,Absolute emission reduction,2009.0,2030,40.0,percent,https://corporate.homedepot.com/responsibility/protecting-the-climate,net_zero_tracker
+net_zero_tracker:R4PP93JZOLY261QX3811:2020,R4PP93JZOLY261QX3811,Absolute emission reduction,2011.0,2020,56.0,percent,https://about.americanexpress.com/corporate-responsibility/sustainability/sustainability/default.aspx,net_zero_tracker
+net_zero_tracker:RCGZFPDMRW58VJ54VR07:2030,RCGZFPDMRW58VJ54VR07,Absolute emission reduction,2018.0,2030,50.0,percent,https://s23.q4cdn.com/574569502/files/doc_governance/2022/Salesforce-ES-Schedules-FY22-EYReport.pdf,net_zero_tracker
+net_zero_tracker:RIFQSET379FOGTEFKS80:2030,RIFQSET379FOGTEFKS80,Absolute emission reduction,2019.0,2030,50.0,percent,https://www.franklinresources.com/ftresources/investor-relations/annual-report#maintaining-fiscal-responsibility-,net_zero_tracker
+net_zero_tracker:RIMU48P07456QXSO0R61:2020,RIMU48P07456QXSO0R61,Absolute emission reduction,2010.0,2020,30.0,percent,https://www.northropgrumman.com/wp-content/uploads/2021-NG-Sustainability-Report_Final.pdf,net_zero_tracker
+net_zero_tracker:RVHJWBXLJ1RFUBSY1F30:2025,RVHJWBXLJ1RFUBSY1F30,Absolute emission reduction,2017.0,2025,25.0,percent,https://www.boeing.com/resources/boeingdotcom/principles/sustainability/assets/data/2021_Boeing_Sustainability_Report.pdf,net_zero_tracker
+net_zero_tracker:SQ95QG8SR5Q56LSNF682:2030,SQ95QG8SR5Q56LSNF682,Absolute emission reduction,2019.0,2030,46.0,percent,https://www.illumina.com/content/dam/illumina-marketing/documents/company/illumina-csr-report-2022.pdf,net_zero_tracker
+net_zero_tracker:T2ZG1WRWZ4BUCMQL9224:2030,T2ZG1WRWZ4BUCMQL9224,Absolute emission reduction,2017.0,2030,90.0,percent,https://www.gapinc.com/en-us/values/sustainability/environment/energy-climate,net_zero_tracker
+net_zero_tracker:TL2N6M87CW970S5SV098:2025,TL2N6M87CW970S5SV098,Absolute emission reduction,2017.0,2025,24.0,percent,https://www.naturgy.com/files/Taxonomia_ENG.pdf,net_zero_tracker
+net_zero_tracker:TSI2PJM6EPETEQ4X1U25:2025,TSI2PJM6EPETEQ4X1U25,Absolute emission reduction,2019.0,2025,70.0,percent,https://www.infineon.com/dgdl/Sustainability+at+Infineon+Supplementing+the+Annual+Report+2021.pdf?fileId=8ac78c8b7d507352017d6b57a9f6016c,net_zero_tracker
+net_zero_tracker:UE2136O97NLB5BYP9H04:2030,UE2136O97NLB5BYP9H04,Absolute emission reduction,2015.0,2030,36.0,percent,https://corporate.mcdonalds.com/content/dam/gwscorp/assets/our-planet/climate-action/McDonalds-2021-Climate-Risk-and-Resiliency-Summary.pdf,net_zero_tracker
+net_zero_tracker:UWJKFUJFZ02DKWI3RY53:2030,UWJKFUJFZ02DKWI3RY53,Absolute emission reduction,2015.0,2030,25.0,percent,https://www.coca-colacompany.com/content/dam/journey/us/en/reports/coca-cola-business-environmental-social-governance-report-2021.pdf,net_zero_tracker
+net_zero_tracker:VGRQXHF3J8VDLUA7XE92:2025,VGRQXHF3J8VDLUA7XE92,Absolute emission reduction,2010.0,2025,65.0,percent,https://www.ibm.com/ibm/environment/annual/IBMEnvReport_2020.pdf,net_zero_tracker
+net_zero_tracker:W38RGI023J3WT1HWRP32:2030,W38RGI023J3WT1HWRP32,Absolute emission reduction,2020.0,2030,20.0,percent,https://assets.new.siemens.com/siemens/assets/api/uuid:4806da09-01c7-40b1-af91-99af4b726653/sustainability2021-en.pdf,net_zero_tracker
+net_zero_tracker:W8J5WZB5IY3K0NDQT671:2032,W8J5WZB5IY3K0NDQT671,Absolute emission reduction,2019.0,2032,55.0,percent,https://www.biogen.com/en_us/healthy-climate-healthy-lives.html,net_zero_tracker
+net_zero_tracker:WAFCR4OKGSC504WU3E95:2025,WAFCR4OKGSC504WU3E95,Absolute emission reduction,2016.0,2025,40.0,percent,https://corporate.lowes.com/sites/lowes-corp/files/2021-07/2020_CSR_FINAL.pdf,net_zero_tracker
+net_zero_tracker:WD6L6041MNRW1JE49D58:2030,WD6L6041MNRW1JE49D58,Absolute emission reduction,2016.0,2030,30.0,percent,https://www.tysonfoods.com/news/news-releases/2021/6/tyson-foods-targets-2050-achieve-net-zero-greenhouse-gas-emissions,net_zero_tracker
+net_zero_tracker:WFLLPEPC7FZXENRZV188:2025,WFLLPEPC7FZXENRZV188,Absolute emission reduction,2018.0,2025,20.0,percent,https://www.bnymellon.com/content/dam/bnymellon/documents/pdf/2020-enterprise-esg-report.pdf.coredownload.pdf,net_zero_tracker
+net_zero_tracker:WHENKOULSSK7WUM60H03:2030,WHENKOULSSK7WUM60H03,Absolute emission reduction,2016.0,2030,20.0,percent,https://whirlpoolcorp.com/2021SustainabilityReport/downloads/whirlpool_2021_sr.pdf,net_zero_tracker
+net_zero_tracker:WPTL2Z3FIYTHSP5V2253:2030,WPTL2Z3FIYTHSP5V2253,Relative emission reduction,2016.0,2030,50.0,percent,https://www.conocophillips.com/sustainability/managing-climate-related-risks/metrics-targets/ghg-target/,net_zero_tracker
+net_zero_tracker:XRZQ5S7HYJFPHJ78L959:2030,XRZQ5S7HYJFPHJ78L959,Absolute emission reduction,2005.0,2030,50.0,percent,https://ameren.mediaroom.com/2020-09-28-Ameren-establishes-net-zero-carbon-emissions-goal-and-a-transformative-expansion-of-wind-and-solar-energy,net_zero_tracker
+net_zero_tracker:XSGZFLO9YTNO9VCQV219:2030,XSGZFLO9YTNO9VCQV219,Absolute emission reduction,2017.0,2030,55.0,percent,https://www.altria.com/en/responsibility/protect-the-environment,net_zero_tracker
+net_zero_tracker:XWTZDRYZPBUHIQBKDB46:2025,XWTZDRYZPBUHIQBKDB46,Relative emission reduction,2020.0,2025,0.0,percent,https://www.eogresources.com/sustainability/,net_zero_tracker
+net_zero_tracker:Y6X4K52KMJMZE7I7MY94:2025,Y6X4K52KMJMZE7I7MY94,Absolute emission reduction,2019.0,2025,25.0,percent,https://www.spglobal.com/esg/insights/the-journey-to-net-zero-at-sp-global,net_zero_tracker
+net_zero_tracker:Y87794H0US1R65VBXU25:2025,Y87794H0US1R65VBXU25,Absolute emission reduction,2015.0,2025,35.0,percent,https://corporate.walmart.com/esgreport/esg-issues/climate-change,net_zero_tracker
+net_zero_tracker:YMEGZFW4SBUSS5BQXF88:2030,YMEGZFW4SBUSS5BQXF88,Absolute emission reduction,2020.0,2030,42.0,percent,https://www.colgatepalmolive.com/content/dam/cp-sites/corporate/corporate/common/pdf/sustainability/colgate-palmolive-sustainability-and-social-impact-final-report-2021.pdf,net_zero_tracker
+net_zero_tracker:ZUNI8PYC725B6H8JU438:2030,ZUNI8PYC725B6H8JU438,Absolute emission reduction,2019.0,2030,25.0,percent,https://www.cummins.com/sites/default/files/2021-05/cummins-tcfd-report-05-19-2021.pdf,net_zero_tracker
+net_zero_tracker:AD:2050,AD,Climate neutral,,2050,,,https://unfccc.int/sites/default/files/NDC/2022-11/20222410_Actualitzacio%20NDC.pdf,net_zero_tracker
+net_zero_tracker:AE:2050,AE,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/United%20Arab%20Emirates%20Second/UAE%20Second%20NDC%20-%20UNFCCC%20Submission%20-%20English%20-%20FINAL.pdf,net_zero_tracker
+net_zero_tracker:AF:2050,AF,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:AG:2040,AG,Net zero,,2040,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Antigua%20and%20Barbuda%20First/ATG%20-%20UNFCCC%20NDC%20-%202021-09-02%20-%20Final.pdf,net_zero_tracker
+net_zero_tracker:AM:2050,AM,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Armenia%20First/NDC%20of%20Republic%20of%20Armenia%20%202021-2030.pdf,net_zero_tracker
+net_zero_tracker:AR:2050,AR,Net zero,,2050,,,https://climateactiontracker.org/countries/argentina/targets/,net_zero_tracker
+net_zero_tracker:AT:2050,AT,Climate neutral,,2050,,,https://www.climatewatchdata.org/countries/AUT?end_year=2018&start_year=1990#ndc-content-overview,net_zero_tracker
+net_zero_tracker:AU:2050,AU,Net zero,,2050,,,https://unfccc.int/sites/default/files/NDC/2022-06/Australias%20NDC%20June%202022%20Update%20%283%29.pdf,net_zero_tracker
+net_zero_tracker:BB:2030,BB,Climate neutral,,2030,,,https://htmlpreview.github.io/?https://github.com/WRI-ClimateWatch/ndc/blob/master/BRB-revised_first_ndc-EN.html,net_zero_tracker
+net_zero_tracker:BD:2050,BD,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Bangladesh%20First/NDC_submission_20210826revised.pdf,net_zero_tracker
+net_zero_tracker:BE:2050,BE,Climate neutral,,2050,,,https://unfccc.int/sites/default/files/resource/LTS_BE_EN_summary.pdf,net_zero_tracker
+net_zero_tracker:BF:2050,BF,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:BG:2050,BG,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/12/1312-Annex-Alliance-ENGLISH-VF-2012.pdf,net_zero_tracker
+net_zero_tracker:BH:2060,BH,Net zero,,2060,,,https://www.arabianbusiness.com/industries-energy/470085-bahrain-pledges-to-reach-net-zero-emissions-by-2060,net_zero_tracker
+net_zero_tracker:BI:2050,BI,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/12/1312-Annex-Alliance-ENGLISH-VF-2012.pdf,net_zero_tracker
+net_zero_tracker:BJ:2000,BJ,Net zero,,2000,,,https://unfccc.int/sites/default/files/NDC/2022-06/CDN_ACTUALISEE_BENIN2021.pdf,net_zero_tracker
+net_zero_tracker:BR:2050,BR,Climate neutral,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Brazil%20First/2021%20-%20Carta%20MRE.pdf,net_zero_tracker
+net_zero_tracker:BS:2050,BS,Net zero,,2050,,,https://unfccc.int/sites/default/files/NDC/2022-11/Bahamas%20Updated%20Nationally%20Determined%20Contributio,net_zero_tracker
+net_zero_tracker:BT:2030,BT,Climate neutral,,2030,,,https://htmlpreview.github.io/?https://github.com/WRI-ClimateWatch/ndc/blob/master/BTN-second_ndc-EN.html,net_zero_tracker
+net_zero_tracker:BZ:2050,BZ,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Belize%20First/Belize%20Updated%20NDC.pdf,net_zero_tracker
+net_zero_tracker:CA:2050,CA,Net zero,,2050,,,https://www.canada.ca/en/services/environment/weather/climatechange/climate-plan/net-zero-emissions-2050.html,net_zero_tracker
+net_zero_tracker:CF:2050,CF,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:CH:2050,CH,Net zero,,2050,,,https://www.admin.ch/gov/en/start/documentation/media-releases.msg-id-82140.html,net_zero_tracker
+net_zero_tracker:CL:2050,CL,Climate neutral,,2050,,,https://www.bcn.cl/leychile/navegar?idNorma=1177286,net_zero_tracker
+net_zero_tracker:CN:2060,CN,GHG neural,,2060,,,https://unfccc.int/sites/default/files/NDC/2022-11/Progress%20of%20China%20NDC%202022.pdf,net_zero_tracker
+net_zero_tracker:CO:2050,CO,Climate neutral,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Colombia%20First/NDC%20actualizada%20de%20Colombia.pdf,net_zero_tracker
+net_zero_tracker:CR:2050,CR,Net zero,,2050,,,https://cambioclimatico.go.cr/wp-content/uploads/2020/01/NationalDecarbonizationPlan.pdf,net_zero_tracker
+net_zero_tracker:CV:2050,CV,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Cabo%20Verde%20First/Cabo%20Verde_NDC%20Update%202021.pdf,net_zero_tracker
+net_zero_tracker:CY:2050,CY,Climate neutral,,2050,,,https://ec.europa.eu/energy/sites/default/files/documents/cy_final_necp_main_en.pdf,net_zero_tracker
+net_zero_tracker:DE:2045,DE,Climate neutral,,2045,,,https://www.bundesregierung.de/breg-de/themen/klimaschutz/climate-change-act-2021-1936846,net_zero_tracker
+net_zero_tracker:DK:2050,DK,Net zero,,2050,,,https://en.kefm.dk/news/news-archive/2019/dec/during-the-cop-denmark-passes-climate-act-with-a-70-percent-reduction-targetws-page-eng,net_zero_tracker
+net_zero_tracker:DO:2050,DO,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Dominican%20Republic%20First/INDC-DR%20August%202015%20(unofficial%20translation).pdf,net_zero_tracker
+net_zero_tracker:EC:2050,EC,Net zero,,2050,,,https://www.ambiente.gob.ec/ministerio-pone-en-marcha-el-programa-ecuador-carbono-cero/,net_zero_tracker
+net_zero_tracker:EE:2050,EE,Climate neutral,,2050,,,https://www.europarl.europa.eu/thinktank/de/document.html?reference=EPRS_BRI%282021%29690684,net_zero_tracker
+net_zero_tracker:ER:2050,ER,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/12/1312-Annex-Alliance-ENGLISH-VF-2012.pdf,net_zero_tracker
+net_zero_tracker:ES:2050,ES,Climate neutral,,2050,,,https://boe.es/buscar/act.php?id=BOE-A-2021-8447#top,net_zero_tracker
+net_zero_tracker:ET:2050,ET,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Ethiopia%20First/Ethiopia%27s%20updated%20NDC%20JULY%202021%20Submission_.pdf,net_zero_tracker
+net_zero_tracker:FI:2035,FI,Climate neutral,,2035,,,https://ym.fi/en/finland-s-national-climate-change-policy,net_zero_tracker
+net_zero_tracker:FJ:2050,FJ,Net zero,,2050,,,https://unfccc.int/sites/default/files/resource/Fiji_Low%20Emission%20Development%20%20Strategy%202018%20-%202050.pdf,net_zero_tracker
+net_zero_tracker:FM:2050,FM,Net zero,,2050,,,https://unfccc.int/sites/default/files/NDC/2022-10/Updated_NDC_of_the_Federated_States_of_Micronesia.pdf,net_zero_tracker
+net_zero_tracker:FR:2050,FR,Net zero,,2050,,,https://www.climatewatchdata.org/countries/FRA,net_zero_tracker
+net_zero_tracker:GB:2050,GB,Net zero,,2050,,,https://unfccc.int/sites/default/files/NDC/2022-09/UK%20NDC%20ICTU%202022.pdf,net_zero_tracker
+net_zero_tracker:GD:2050,GD,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Grenada%20Second/GrenadaSecondNDC2020%20-%2001-12-20.pdf,net_zero_tracker
+net_zero_tracker:GH:2070,GH,Net zero,,2070,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Ghana%20First/Ghana's%20Updated%20Nationally%20Determined%20Contribution%20to%20the%20UNFCCC_2021.pdf,net_zero_tracker
+net_zero_tracker:GM:2050,GM,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Gambia%20Second%20NDC/Second%20NDC%20of%20The%20Republic%20of%20The%20Gambia.pdf,net_zero_tracker
+net_zero_tracker:GN:2050,GN,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:GR:2050,GR,Climate neutral,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Greece%20First/EU_NDC_Submission_December%202020.pdf,net_zero_tracker
+net_zero_tracker:GW:2030,GW,Net zero,,2030,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Guinea-Bissau%20First/NDC-Guinea%20Bissau-12102021.Final.pdf,net_zero_tracker
+net_zero_tracker:GY:2019,GY,Net zero,,2019,,,http://spappssecext.worldbank.org/sites/indc/PDF_Library/gy.pdf,net_zero_tracker
+net_zero_tracker:HR:2050,HR,Net zero,,2050,,,https://mingor.gov.hr/UserDocsImages/klimatske_aktivnosti/odrzivi_razvoj/NUS/lts_nus_eng.pdf,net_zero_tracker
+net_zero_tracker:HU:2050,HU,Net zero,,2050,,,https://www.parlament.hu/irom41/07021/07021-0010.pdf,net_zero_tracker
+net_zero_tracker:ID:2060,ID,Net zero,,2060,,,https://unfccc.int/sites/default/files/NDC/2022-09/ENDC%20Indonesia.pdf,net_zero_tracker
+net_zero_tracker:IE:2050,IE,Net zero,,2050,,,https://static.rasset.ie/documents/news/2020/06/draft-programme-for-govt.pdfhttps://www.gov.ie/pdf/?file=https://assets.gov.ie/42213/752d5346b9c6407b9125fdadfa0738a4.pdf#page=1,net_zero_tracker
+net_zero_tracker:IL:2050,IL,Net zero,,2050,,,https://www.jpost.com/climate-change/cop26-israel-to-aim-for-zero-net-emissions-by-2050-683470,net_zero_tracker
+net_zero_tracker:IN:2070,IN,Net zero,,2070,,,https://unfccc.int/sites/default/files/NDC/2022-08/India%20Updated%20First%20Nationally%20Determined%20Contrib.pdf,net_zero_tracker
+net_zero_tracker:IS:2040,IS,Climate neutral,,2040,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Iceland%20First/Iceland_updated_NDC_Submission_Feb_2021.pdf,net_zero_tracker
+net_zero_tracker:IT:2050,IT,Climate neutral,,2050,,,https://ec.europa.eu/clima/sites/lts/lts_it_it.pdf,net_zero_tracker
+net_zero_tracker:JM:2050,JM,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Jamaica%20First/Updated%20NDC%20Jamaica%20-%20ICTU%20Guidance.pdf,net_zero_tracker
+net_zero_tracker:JP:2050,JP,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Japan%20First/JAPAN_FIRST%20NDC%20(INTERIM-UPDATED%20SUBMISSION).pdf,net_zero_tracker
+net_zero_tracker:KH:2050,KH,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:KI:2050,KI,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:KM:2050,KM,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:KR:2050,KR,Net zero,,2050,,,https://unfccc.int/sites/default/files/NDC/2022-06/211223_The%20Republic%20of%20Korea%27s%20Enhanced%20Update%20of%20its%20First%20Nationally%20Determined%20Contribution_211227_editorial%20change.pdf,net_zero_tracker
+net_zero_tracker:KZ:2060,KZ,Net zero,,2060,,,https://legalacts.egov.kz/npa/view?id=11488215,net_zero_tracker
+net_zero_tracker:LA:2050,LA,Net zero,,2050,,,"https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Lao%20People%27s%20Democratic%20Republic%20First/NDC%202020%20of%20Lao%20PDR%20(English),%2009%20April%202021%20(1).pdf",net_zero_tracker
+net_zero_tracker:LB:2050,LB,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Lebanon%20First/Lebanon%27s%202020%20Nationally%20Determined%20Contribution%20Update.pdf,net_zero_tracker
+net_zero_tracker:LK:2060,LK,Climate neutral,,2060,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Sri%20Lanka%20First/NDCs%20of%20Sri%20Lanka-2021.pdf,net_zero_tracker
+net_zero_tracker:LR:2050,LR,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Liberia%20First/INDC%20Final%20Submission%20Sept%2030%202015%20Liberia.pdf,net_zero_tracker
+net_zero_tracker:LS:2050,LS,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Lesotho%20First/Lesotho%20First%20NDC.pdf,net_zero_tracker
+net_zero_tracker:LT:2050,LT,Net zero,,2050,,,https://www.oecd-ilibrary.org/environment/oecd-environmental-performance-reviews-lithuania-2021_48d82b17-en,net_zero_tracker
+net_zero_tracker:LU:2050,LU,Net zero,,2050,,,"https://legilux.public.lu/eli/etat/leg/loi/2020/12/15/a994/jo#:~:text=La%20pr%C3%A9sente%20loi%20%C3%A9tablit%20un,par%20rapport%20aux%20niveaux%20pr%C3%A9industriels.",net_zero_tracker
+net_zero_tracker:LV:2050,LV,Net zero,,2050,,,https://ec.europa.eu/clima/sites/lts/lts_lv_en.pdf,net_zero_tracker
+net_zero_tracker:MC:2050,MC,Net zero,,2050,,,https://www.docdroid.net/gavlB6o/190922-rmi-unsg-summit-release-leaders-statement-final-combined-pdf,net_zero_tracker
+net_zero_tracker:MG:2010,MG,Net zero,,2010,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Madagascar%20First/Madagascar%20INDC%20Eng.pdf,net_zero_tracker
+net_zero_tracker:MH:2050,MH,Net zero,,2050,,,https://unfccc.int/sites/default/files/resource/180924%20rmi%202050%20climate%20strategy%20final_0.pdf,net_zero_tracker
+net_zero_tracker:ML:2050,ML,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/12/1312-Annex-Alliance-ENGLISH-VF-2012.pdf,net_zero_tracker
+net_zero_tracker:MM:2050,MM,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/12/1312-Annex-Alliance-ENGLISH-VF-2012.pdf,net_zero_tracker
+net_zero_tracker:MR:2030,MR,Climate neutral,,2030,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Mauritania%20First/CDN-actualis%C3%A9%202021_%20Mauritania.pdf,net_zero_tracker
+net_zero_tracker:MT:2050,MT,Climate neutral,,2050,,,https://meae.gov.mt/en/Public_Consultations/MECP/PublishingImages/Pages/Consultations/MaltasLowCarbonDevelopmentStrategy/Malta%20Low%20Carbon%20Development%20Strategy.pdf,net_zero_tracker
+net_zero_tracker:MU:2050,MU,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Mauritius%20First/Final%20INDC%20for%20Mauritius%2028%20Sept%202015.pdf,net_zero_tracker
+net_zero_tracker:MV:2030,MV,Net zero,,2030,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Maldives%20First/Maldives%20Nationally%20Determined%20Contribution%202020.pdf,net_zero_tracker
+net_zero_tracker:MW:2050,MW,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Malawi%20First/Malawi%20NDC_Policy%20Brief_30%20June%202021.pdf,net_zero_tracker
+net_zero_tracker:MX:2050,MX,Climate neutral,,2050,,,https://unfccc.int/sites/default/files/NDC/2022-11/Mexico_NDC_UNFCCC_update2022_FINAL.pdf,net_zero_tracker
+net_zero_tracker:MY:2050,MY,Climate neutral,,2050,,,https://rmke12.epu.gov.my/en,net_zero_tracker
+net_zero_tracker:NA:2050,NA,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Namibia%20First/Namibia%27s%20Updated%20NDC_%20FINAL%2025%20July%202021.pdf,net_zero_tracker
+net_zero_tracker:NE:2050,NE,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:NG:2060,NG,Net zero,,2060,,,https://www.bloomberg.com/news/articles/2021-11-02/nigeria-targets-to-reach-net-zero-emissions-by-2060-buhari-says,net_zero_tracker
+net_zero_tracker:NI:2050,NI,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:NP:2045,NP,Net zero,,2045,,,https://english.onlinekhabar.com/cop26-nepal-promises.html,net_zero_tracker
+net_zero_tracker:NR:2050,NR,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:NU:2050,NU,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Niue%20First/Niue%20INDC%20Final.pdf,net_zero_tracker
+net_zero_tracker:OM:2050,OM,Net zero,,2050,,,https://www.muscatdaily.com/2022/10/11/oman-commits-to-net-zero-by-2050/,net_zero_tracker
+net_zero_tracker:PA:2050,PA,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Panama%20First/CDN1%20Actualizada%20Rep%C3%BAblica%20de%20Panam%C3%A1.pdf,net_zero_tracker
+net_zero_tracker:PE:2050,PE,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Peru%20First/Reporte%20de%20Actualizacio%CC%81n%20de%20las%20NDC%20del%20Peru%CC%81.pdf,net_zero_tracker
+net_zero_tracker:PG:2050,PG,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Papua%20New%20Guinea%20First/PNG_INDC%20to%20the%20UNFCCC.pdf,net_zero_tracker
+net_zero_tracker:PK:2050,PK,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Pakistan%20First/Pakistan%20Updated%20NDC%202021.pdf,net_zero_tracker
+net_zero_tracker:PT:2050,PT,Climate neutral,,2050,,,https://unfccc.int/sites/default/files/resource/HR-03-06-2020%20EU%20Submission%20on%20Long%20term%20strategy.pdf,net_zero_tracker
+net_zero_tracker:PW:2050,PW,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Palau%20First/Palau_INDC.Final%20Copy.pdf,net_zero_tracker
+net_zero_tracker:RO:2050,RO,Climate neutral,,2050,,,https://ec.europa.eu/energy/sites/default/files/documents/ro_final_necp_main_en.pdf,net_zero_tracker
+net_zero_tracker:RU:2060,RU,Climate neutral,,2060,,,http://static.government.ru/media/files/ADKkCzp3fWO32e2yA0BhtIpyzWfHaiUa.pdf,net_zero_tracker
+net_zero_tracker:RW:2050,RW,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:SA:2060,SA,Net zero,,2060,,,https://www.bloomberg.com/news/articles/2021-10-23/world-s-biggest-oil-exporter-commits-to-net-zero-emissions,net_zero_tracker
+net_zero_tracker:SB:2050,SB,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Solomon%20Islands%20First/NDC%20Report%202021%20Final%20Solomon%20Islands%20(1).pdf,net_zero_tracker
+net_zero_tracker:SC:2050,SC,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:SE:2045,SE,Net zero,,2045,,,https://www.government.se/495f60/contentassets/883ae8e123bc4e42aa8d59296ebe0478/the-swedish-climate-policy-framework.pdf,net_zero_tracker
+net_zero_tracker:SG:2050,SG,Net zero,,2050,,,https://www.nccs.gov.sg/files/docs/default-source/publications/nccsleds_addendum_2022.pdf,net_zero_tracker
+net_zero_tracker:SI:2050,SI,Climate neutral,,2050,,,https://unfccc.int/sites/default/files/resource/LTS1_SLOVENIA_EN.pdf,net_zero_tracker
+net_zero_tracker:SK:2050,SK,Net zero,,2050,,,https://unfccc.int/sites/default/files/resource/LTS%20SK%20eng.pdf,net_zero_tracker
+net_zero_tracker:SL:2050,SL,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:SN:2050,SN,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:SO:2050,SO,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Somalia%20First/Final%20Updated%20NDC%20for%20Somalia%202021.pdf,net_zero_tracker
+net_zero_tracker:ST:2050,ST,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:TD:2050,TD,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:TG:2050,TG,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:TH:2065,TH,Net zero,,2065,,,https://unfccc.int/sites/default/files/NDC/2022-11/Thailand%202nd%20Updated%20NDC.pdf,net_zero_tracker
+net_zero_tracker:TO:2050,TO,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:TR:2053,TR,Net zero,,2053,,,https://www2.tbmm.gov.tr/d27/2/2-3853.pdf,net_zero_tracker
+net_zero_tracker:TT:2050,TT,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:TV:2050,TV,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:TZ:2050,TZ,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/12/1312-Annex-Alliance-ENGLISH-VF-2012.pdf,net_zero_tracker
+net_zero_tracker:UA:2060,UA,Climate neutral,,2060,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Ukraine%20First/Ukraine%20NDC_July%2031.pdf,net_zero_tracker
+net_zero_tracker:US:2050,US,Net zero,,2050,,,https://www.whitehouse.gov/wp-content/uploads/2021/10/US-Long-Term-Strategy.pdf,net_zero_tracker
+net_zero_tracker:UY:2050,UY,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:VC:2050,VC,Net zero,,2050,,,https://www4.unfccc.int/sites/ndcstaging/PublishedDocuments/Saint%20Vincent%20and%20the%20Grenadines%20First/Saint%20Vincent%20and%20the%20Grenadines_NDC.pdf,net_zero_tracker
+net_zero_tracker:VN:2050,VN,Net zero,,2050,,,https://unfccc.int/sites/default/files/NDC/2022-11/Viet%20Nam%20NDC%202022%20Update.pdf,net_zero_tracker
+net_zero_tracker:WS:2050,WS,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:YE:2050,YE,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:ZA:2050,ZA,Net zero,,2050,,,https://unfccc.int/sites/default/files/resource/South%20Africa%27s%20Low%20Emission%20Development%20Strategy.pdf,net_zero_tracker
+net_zero_tracker:ZM:2050,ZM,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:AU-ACT:2045,AU-ACT,Net zero,,2045,,,"https://www.environment.act.gov.au/__data/assets/pdf_file/0003/1414641/ACT-Climate-Change-Strategy-2019-2025.pdf/_recache#:~:text=The%20Australian%20Capital%20Territory%20(ACT,reduction%20in%20emissions%20by%202020.",net_zero_tracker
+net_zero_tracker:AU-NSW:2050,AU-NSW,Net zero,,2050,,,https://www.energy.nsw.gov.au/nsw-plans-and-progress/government-strategies-and-frameworks/reaching-net-zero-emissions,net_zero_tracker
+net_zero_tracker:AU-NT:2050,AU-NT,Net zero,,2050,,,https://depws.nt.gov.au/__data/assets/pdf_file/0005/904775/northern-territory-climate-change-response-towards-2050.pdf,net_zero_tracker
+net_zero_tracker:AU-QLD:2050,AU-QLD,Net zero,,2050,,,https://www.qld.gov.au/__data/assets/pdf_file/0026/67283/qld-climate-transition-strategy.pdf,net_zero_tracker
+net_zero_tracker:AU-SA:2050,AU-SA,Net zero,,2050,,,https://www.environment.sa.gov.au/topics/climate-change/government-action-on-climate-change,net_zero_tracker
+net_zero_tracker:AU-TAS:2030,AU-TAS,Net zero,,2030,,,https://www.dpac.tas.gov.au/__data/assets/pdf_file/0029/136829/Tasmanian_Emissions_Pathway_Review_-_Summary_Report.pdf,net_zero_tracker
+net_zero_tracker:AU-VIC:2045,AU-VIC,Net zero,,2045,,,https://www.danandrews.com.au/news/putting-power-back-in-the-hands-of-victorians,net_zero_tracker
+net_zero_tracker:AU-WA:2050,AU-WA,Net zero,,2050,,,https://www.wa.gov.au/system/files/2020-12/Western_Australian_Climate_Policy.pdf,net_zero_tracker
+net_zero_tracker:BR-MA:2050,BR-MA,Net zero,,2050,,,https://www.ma.gov.br/agenciadenoticias/?p=314497,net_zero_tracker
+net_zero_tracker:BR-PA:2050,BR-PA,Net zero,,2050,,,https://agenciapara.com.br/noticia/30336/,net_zero_tracker
+net_zero_tracker:CA-MB:2080,CA-MB,Climate neutral,,2080,,,https://www.gov.mb.ca/sd/annual-reports/sdif/mb-climate-change-green-economy-action-plan.pdf,net_zero_tracker
+net_zero_tracker:CA-NS:2050,CA-NS,Net zero,,2050,,,https://nslegislature.ca/legc/bills/63rd_2nd/3rd_read/b213.htm,net_zero_tracker
+net_zero_tracker:CA-NT:2050,CA-NT,Net zero,,2050,,,https://www.ntassembly.ca/sites/assembly/files/td_103-192.pdf,net_zero_tracker
+net_zero_tracker:CA-PE:2040,CA-PE,Net zero,,2040,,,https://www.princeedwardisland.ca/sites/default/files/publications/pei_path_towards_net_zero_framework.pdf,net_zero_tracker
+net_zero_tracker:CA-QC:2050,CA-QC,Climate neutral,,2050,,,https://www.quebec.ca/en/government/policies-orientations/plan-green-economy,net_zero_tracker
+net_zero_tracker:CA-YT:2050,CA-YT,Net zero,,2050,,,https://yukon.ca/sites/yukon.ca/files/env/env-our-clean-future.pdf,net_zero_tracker
+net_zero_tracker:CN-HI:2050,CN-HI,Climate neutral,,2050,,,https://www.ndrc.gov.cn/fggz/gbzj/xtfc/202102/t20210203_1266787.html?code=&state=123,net_zero_tracker
+net_zero_tracker:DE-BB:2045,DE-BB,Climate neutral,,2045,,,https://www.pnn.de/brandenburg/klimaschutz-in-der-mark-2045-soll-brandenburg-klimaneutral-sein/27365668.html,net_zero_tracker
+net_zero_tracker:DE-BE:2045,DE-BE,Climate neutral,,2045,,,https://gesetze.berlin.de/bsbe/document/jlr-EWendGBErahmen,net_zero_tracker
+net_zero_tracker:DE-BW:2040,DE-BW,Climate neutral,,2040,,,https://um.baden-wuerttemberg.de/fileadmin/redaktion/m-um/intern/Dateien/Dokumente/4_Klima/Klimaschutz/Klimaschutzgesetz/Klimaschutzgesetz-Baden-Wuerttemberg-englische-Fassung-Januar-2021.pdf,net_zero_tracker
+net_zero_tracker:DE-BY:2050,DE-BY,Climate neutral,,2050,,,https://www.gesetze-bayern.de/Content/Document/BayKlimaG,net_zero_tracker
+net_zero_tracker:DE-HE:2030,DE-HE,Climate neutral,,2030,,,https://co2.hessen-nachhaltig.de/ueber-uns.html,net_zero_tracker
+net_zero_tracker:DE-NW:2045,DE-NW,GHG neural,,2045,,,https://www.klimaschutz.nrw.de/instrumente/klimaschutzgesetz,net_zero_tracker
+net_zero_tracker:DE-RP:2050,DE-RP,Climate neutral,,2050,,,https://www.theclimategroup.org/sites/default/files/2020-10/Rhineland-Palatinate-Appendix-English.pdf,net_zero_tracker
+net_zero_tracker:ES-CN:2040,ES-CN,Net zero,,2040,,,https://www3.gobiernodecanarias.org/ceic/energia/oecan/files/20220214_Estrategia_Sostenible_Canarias_docCompleto_01.pdf,net_zero_tracker
+net_zero_tracker:ES-CT:2050,ES-CT,GHG neural,,2050,,,https://canviclimatic.gencat.cat/ca/ambits/Llei_canvi_climatic/,net_zero_tracker
+net_zero_tracker:FR-IDF:2050,FR-IDF,Net zero,,2050,,,https://www.iledefrance.fr/sites/default/files/2021-03/green_social_and_sustainable_bond_framework.pdf,net_zero_tracker
+net_zero_tracker:FR-PAC:2050,FR-PAC,Climate neutral,,2050,,,http://www.grec-sud.fr/wp-content/uploads/2019/11/cahier_sante_GREC-SUD_11122019.pdf,net_zero_tracker
+net_zero_tracker:GB-ENG:2050,GB-ENG,Net zero,,2050,,,https://www.gov.uk/government/news/uk-enshrines-new-target-in-law-to-slash-emissions-by-78-by-2035,net_zero_tracker
+net_zero_tracker:GB-NIR:2050,GB-NIR,Net zero,,2050,,,http://www.niassembly.gov.uk/globalassets/documents/legislation/bills/executive-bills/session-2017-2022/climate-change-no.-2-bill/climate-chnage-no.-2-bill-as-amended-at-fcs---full-print-version.pdf,net_zero_tracker
+net_zero_tracker:GB-SCT:2045,GB-SCT,Net zero,,2045,,,https://www.legislation.gov.uk/asp/2019/15/contents/enacted,net_zero_tracker
+net_zero_tracker:GB-WLS:2050,GB-WLS,Net zero,,2050,,,https://gov.wales/sites/default/files/publications/2021-10/net-zero-wales-summary-document.pdf,net_zero_tracker
+net_zero_tracker:ID-JK:2050,ID-JK,Climate neutral,,2050,,,https://www.iges.or.jp/sites/default/files/inline-files/S2-5_Erni%20Pelita%20Fitratunnisa_Jakarta.pdf,net_zero_tracker
+net_zero_tracker:IN-WB:2030,IN-WB,Climate neutral,,2030,,,http://www.environmentwb.gov.in/pdf/WBSAPCC_2017_20.pdf,net_zero_tracker
+net_zero_tracker:JP-01:2050,JP-01,Net zero,,2050,,,https://www.pref.hokkaido.lg.jp/ks/tot/ontaikeikakukaitei.html,net_zero_tracker
+net_zero_tracker:JP-02:2050,JP-02,Net zero,,2050,,,https://www.pref.aomori.lg.jp/soshiki/kankyo/kankyo/2050CO2zero.html,net_zero_tracker
+net_zero_tracker:JP-03:2050,JP-03,Net zero,,2050,,,https://www.pref.iwate.jp/kurashikankyou/kankyou/seisaku/1005573.html,net_zero_tracker
+net_zero_tracker:JP-04:2050,JP-04,Net zero,,2050,,,https://www.env.go.jp/policy/zerocarbon.html,net_zero_tracker
+net_zero_tracker:JP-06:2050,JP-06,Net zero,,2050,,,https://www.pref.yamagata.jp/050015/kurashi/kankyo/management/plan/4thplan.html,net_zero_tracker
+net_zero_tracker:JP-07:2050,JP-07,Net zero,,2050,,,https://www.pref.fukushima.lg.jp/sec/16035a/carbon-neutral.html,net_zero_tracker
+net_zero_tracker:JP-09:2050,JP-09,Net zero,,2050,,,https://www.pref.tochigi.lg.jp/d02/eco/kankyou/ondanka/documents/kikoukeikaku.pdf,net_zero_tracker
+net_zero_tracker:JP-10:2050,JP-10,Net zero,,2050,,,https://www.pref.gunma.jp/04/cp01_00022.html,net_zero_tracker
+net_zero_tracker:JP-12:2050,JP-12,Net zero,,2050,,,https://www.pref.chiba.lg.jp/shigen/chikyuukankyou/zerosengen.html,net_zero_tracker
+net_zero_tracker:JP-13:2050,JP-13,Net zero,,2050,,,https://www.kankyo.metro.tokyo.lg.jp/policy_others/zeroemission_tokyo/strategy_2020update.html,net_zero_tracker
+net_zero_tracker:JP-14:2050,JP-14,Net zero,,2050,,,https://www.pref.kanagawa.jp/documents/59045/datsutanso.pdf,net_zero_tracker
+net_zero_tracker:JP-15:2050,JP-15,Net zero,,2050,,,https://www.pref.niigata.lg.jp/site/kankyo/1239566486047.html,net_zero_tracker
+net_zero_tracker:JP-16:2050,JP-16,Net zero,,2050,,,https://www.pref.toyama.jp/100223/kurashi/kankyoushizen/kankyou/kj00021656.html,net_zero_tracker
+net_zero_tracker:JP-18:2050,JP-18,Net zero,,2050,,,https://www.pref.fukui.lg.jp/doc/kankyou/2050-co2-0.html,net_zero_tracker
+net_zero_tracker:JP-19:2050,JP-19,Net zero,,2050,,,https://www.pref.yamanashi.jp/kankyo-ene/stopondankayamanashikaigi.html,net_zero_tracker
+net_zero_tracker:JP-20:2050,JP-20,Net zero,,2050,,,https://www.pref.nagano.lg.jp/kankyo/keikaku/zerocarbon/index.html,net_zero_tracker
+net_zero_tracker:JP-21:2050,JP-21,Net zero,,2050,,,https://www.pref.gifu.lg.jp/page/8674.html,net_zero_tracker
+net_zero_tracker:JP-22:2050,JP-22,Net zero,,2050,,,https://www.pref.shizuoka.jp/kankyou/ka-030/earth/carbon-neutral.html,net_zero_tracker
+net_zero_tracker:JP-24:2050,JP-24,Net zero,,2050,,,https://www.pref.mie.lg.jp/common/01/ci500015424.htm,net_zero_tracker
+net_zero_tracker:JP-25:2050,JP-25,Net zero,,2050,,,https://www.pref.shiga.lg.jp/ippan/kankyoshizen/ondanka/309038.html,net_zero_tracker
+net_zero_tracker:JP-26:2050,JP-26,Net zero,,2050,,,https://www.pref.kyoto.jp/tikyu/suishinkeikaku.html,net_zero_tracker
+net_zero_tracker:JP-28:2050,JP-28,Net zero,,2050,,,https://www.kankyo.pref.hyogo.lg.jp/application/files/7016/1578/8440/b99e09762bd46d7c8ff9c64976693843.pdf,net_zero_tracker
+net_zero_tracker:JP-29:2050,JP-29,Net zero,,2050,,,http://www.eco.pref.nara.jp/jorei_kisoku/sogo_keikaku.html,net_zero_tracker
+net_zero_tracker:JP-30:2050,JP-30,Net zero,,2050,,,https://www.pref.wakayama.lg.jp/prefg/032000/envplan/index.html,net_zero_tracker
+net_zero_tracker:JP-31:2050,JP-31,Net zero,,2050,,,https://www.pref.tottori.lg.jp/initiative_plan/,net_zero_tracker
+net_zero_tracker:JP-32:2050,JP-32,Net zero,,2050,,,https://www.pref.shimane.lg.jp/infra/kankyo/kankyo/kankyo_sougou/sougoukeikaku.html,net_zero_tracker
+net_zero_tracker:JP-33:2050,JP-33,Net zero,,2050,,,https://www.env.go.jp/policy/zerocarbon.html,net_zero_tracker
+net_zero_tracker:JP-34:2050,JP-34,Net zero,,2050,,,https://www.pref.hiroshima.lg.jp/site/eco/b-b12-plan22-keikaku.html,net_zero_tracker
+net_zero_tracker:JP-36:2050,JP-36,Net zero,,2050,,,https://www.pref.tokushima.lg.jp/ippannokata/kurashi/shizen/5035820,net_zero_tracker
+net_zero_tracker:JP-37:2050,JP-37,Net zero,,2050,,,https://www.pref.kagawa.lg.jp/kankyoseisaku/chikyu/datsutanso/co2zero.html,net_zero_tracker
+net_zero_tracker:JP-38:2050,JP-38,Net zero,,2050,,,https://www.pref.ehime.jp/kankyou/k-hp/theme/ondanka/keikaku.html,net_zero_tracker
+net_zero_tracker:JP-39:2050,JP-39,Net zero,,2050,,,https://www.pref.kochi.lg.jp/soshiki/030901/2021032500328.html,net_zero_tracker
+net_zero_tracker:JP-41:2050,JP-41,Net zero,,2050,,,https://www.pref.saga.lg.jp/kiji00379726/index.html,net_zero_tracker
+net_zero_tracker:JP-42:2050,JP-42,Net zero,,2050,,,https://www.pref.nagasaki.jp/bunrui/kurashi-kankyo/kankyohozen-ondankataisaku/ondanka/ondanka-actionplan-dai2ji/,net_zero_tracker
+net_zero_tracker:JP-43:2050,JP-43,Net zero,,2050,,,https://www.pref.kumamoto.jp/soshiki/49/103587.html,net_zero_tracker
+net_zero_tracker:JP-44:2050,JP-44,Net zero,,2050,,,https://www.pref.oita.jp/soshiki/13060/dai5kikeikaku.html,net_zero_tracker
+net_zero_tracker:JP-45:2050,JP-45,Net zero,,2050,,,http://www.pref.miyazaki.lg.jp/kankyoshinrin/kense/kekaku/20210303113521.html,net_zero_tracker
+net_zero_tracker:JP-46:2050,JP-46,Net zero,,2050,,,http://www.pref.kagoshima.jp/kawara/documents/89273_20210802111303-1.pdf,net_zero_tracker
+net_zero_tracker:JP-47:2030,JP-47,Net zero,,2030,,,https://www.pref.okinawa.jp/site/kankyo/saisei/jikkkou-keikaku.html,net_zero_tracker
+net_zero_tracker:KR-41:2050,KR-41,Climate neutral,,2050,,,https://www.mois.go.kr/cmm/fms/FileDown.do?atchFileId=FILE_00101190L1_eLCh&fileSn=0,net_zero_tracker
+net_zero_tracker:KR-42:2050,KR-42,Climate neutral,,2050,,,https://www.mois.go.kr/cmm/fms/FileDown.do?atchFileId=FILE_00101190L1_eLCh&fileSn=0,net_zero_tracker
+net_zero_tracker:KR-43:2050,KR-43,Climate neutral,,2050,,,http://www.chungnam.go.kr/englishArticle.do?v=view&mnu_cd=ECNMENU10070&pageNo=1&article_no=MD0001693673&searchCnd=TOTAL&searchWrd=carbon%20neutral&start_dt=&end_dt=,net_zero_tracker
+net_zero_tracker:MX-JAL:2050,MX-JAL,Climate neutral,,2050,,,https://app.semadet.jalisco.gob.mx/cs/EECC_15042021.pdf,net_zero_tracker
+net_zero_tracker:TW-KIN:2030,TW-KIN,Net zero,,2030,,,https://lcss.epa.gov.tw/en/news_01_02.html,net_zero_tracker
+net_zero_tracker:TW-TAO:2050,TW-TAO,Net zero,,2050,,,https://www.tydep.gov.tw/tydep/EnglishNewsFront/Detail/343,net_zero_tracker
+net_zero_tracker:TW-TPE:2050,TW-TPE,Net zero,,2050,,,https://english.dep.gov.taipei/News_Content.aspx?n=E56771B61602F277&sms=DFFA119D1FD5602C&s=DB98495198E9A0A0,net_zero_tracker
+net_zero_tracker:TW-TXG:2050,TW-TXG,Net zero,,2050,,,https://www.taichung.gov.tw/2040192/post,net_zero_tracker
+net_zero_tracker:US-CA:2045,US-CA,Net zero,,2045,,,https://www.ca.gov/archive/gov39/wp-content/uploads/2018/09/9.10.18-Executive-Order.pdf,net_zero_tracker
+net_zero_tracker:US-HI:2045,US-HI,Climate neutral,,2045,,,https://www.capitol.hawaii.gov/session2018/bills/HB2182_CD1_.htm,net_zero_tracker
+net_zero_tracker:US-IL:2050,US-IL,Net zero,,2050,,,https://www.illinois.gov/government/executive-orders/executive-order.executive-order-number-6.2019.html,net_zero_tracker
+net_zero_tracker:US-LA:2050,US-LA,Net zero,,2050,,,https://gov.louisiana.gov/assets/ExecutiveOrders/2020/JBE-2020-18-Climate-Initiatives-Task-Force.pdf,net_zero_tracker
+net_zero_tracker:US-MA:2050,US-MA,Net zero,,2050,,,https://malegislature.gov/Laws/SessionLaws/Acts/2021/Chapter8,net_zero_tracker
+net_zero_tracker:US-MD:2045,US-MD,Net zero,,2045,,,https://mgaleg.maryland.gov/2022RS/fnotes/bil_0008/sb0528.pdf,net_zero_tracker
+net_zero_tracker:US-ME:2045,US-ME,Climate neutral,,2045,,,https://www.maine.gov/governor/mills/sites/maine.gov.governor.mills/files/inline-files/Executive%20Order%209-23-2019_0.pdf,net_zero_tracker
+net_zero_tracker:US-MI:2050,US-MI,Climate neutral,,2050,,,https://www.michigan.gov/documents/egle/Draft-MI-Healthy-Climate-Plan_745872_7.pdf,net_zero_tracker
+net_zero_tracker:US-MT:2050,US-MT,GHG neural,,2050,,,http://formergovernors.mt.gov/bullock/docs/2019EOs/EO-08-2019_Creating%20Climate%20Solutions%20Council.pdf,net_zero_tracker
+net_zero_tracker:US-ND:2030,US-ND,Climate neutral,,2030,,,https://www.nd.gov/news/burgum-hosts-energy-secretary-granholm-stresses-all-above-energy-policy-and-carbon,net_zero_tracker
+net_zero_tracker:US-NV:2050,US-NV,Net zero,,2050,,,https://www.leg.state.nv.us/App/NELIS/REL/80th2019/Bill/6431/Text,net_zero_tracker
+net_zero_tracker:US-NY:2050,US-NY,Net zero,,2050,,,https://www.nysenate.gov/legislation/bills/2019/s6599,net_zero_tracker
+net_zero_tracker:US-WA:2050,US-WA,Net zero,,2050,,,https://ecology.wa.gov/Air-Climate/Climate-change/Greenhouse-gases,net_zero_tracker
+net_zero_tracker:ZA-WC:2050,ZA-WC,Net zero,,2050,,,https://www.westerncape.gov.za/eadp/files/atoms/files/WCCCRS%202050%20Draft%20-%20Nov%202021.pdf,net_zero_tracker
+net_zero_tracker:AE DXB:2050,AE DXB,Net zero,,2050,,,https://gulfnews.com/uae/dubais-plan-to-cut-carbon-emissions-30-by-2030-approved-1.85462037,net_zero_tracker
+net_zero_tracker:AR BUE:2050,AR BUE,Climate neutral,,2050,,,https://www.buenosaires.gob.ar/sites/gcaba/files/pac_resumen_ejecutivo_esp_0.pdf,net_zero_tracker
+net_zero_tracker:AR COR:2050,AR COR,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:AR MDZ:2050,AR MDZ,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:AR ROS:2050,AR ROS,Net zero,,2050,,,https://www.rosario.gob.ar/inicio/sites/default/files/2022-06/Plan%20Local%20de%20Acci%C3%B3n%20Clima%CC%81tica%20Rosario%202030.pdf,net_zero_tracker
+net_zero_tracker:AR SLA:2050,AR SLA,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:AU ADL:2025,AU ADL,Climate neutral,,2025,,,https://www.cityofadelaide.com.au/about-adelaide/our-sustainable-city/carbon-neutral-adelaide/,net_zero_tracker
+net_zero_tracker:AU MEL:2050,AU MEL,Net zero,,2050,,,https://www.melbourne.vic.gov.au/sitecollectiondocuments/climate-change-mitigation-strategy-2050.pdf,net_zero_tracker
+net_zero_tracker:AU SYD:2050,AU SYD,Net zero,,2050,,,https://greatercities.au/metropolis-of-three-cities/sustainability/efficient-city/low-carbon-city-contributes-net-zero,net_zero_tracker
+net_zero_tracker:BD DAC:2050,BD DAC,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:BE LGG:2050,BE LGG,Climate neutral,,2050,,,https://www.brusselstimes.com/news/belgium-all-news/45514/reduction-by-21-7-of-greenhouse-gas-emissions-in-liege/,net_zero_tracker
+net_zero_tracker:BR BHZ:2050,BR BHZ,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:BR CWB:2050,BR CWB,Net zero,,2050,,,https://www.curitiba.pr.gov.br/noticias/plano-de-acao-climatica-de-curitiba-comeca-a-ser-implementado-em-2021/57425,net_zero_tracker
+net_zero_tracker:BR FOR:2050,BR FOR,Net zero,,2050,,,https://americadosul.iclei.org/wp-content/uploads/sites/78/2021/07/30-plac-fortaleza-final-ingles.pdf,net_zero_tracker
+net_zero_tracker:BR REC:2050,BR REC,GHG neural,,2050,,,https://americadosul.iclei.org/wp-content/uploads/sites/78/2021/07/30-plac-recife-final-ingles.pdf,net_zero_tracker
+net_zero_tracker:BR RIO:2050,BR RIO,Climate neutral,,2050,,,https://www.citiesoftomorrow.eu/sites/default/files/documents/Executive_Summary_finalok.pdf,net_zero_tracker
+net_zero_tracker:BR SAO:2050,BR SAO,Net zero,,2050,,,https://smastr16.blob.core.windows.net/home/2021/10/cop26_english.pdf,net_zero_tracker
+net_zero_tracker:BR SSA:2049,BR SSA,Climate neutral,,2049,,,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5c8ab5851647e100801756a3/60abe3e2795a8b00a674dd75/files/PMAMC_Ebook_ingles.pdf?1621877739,net_zero_tracker
+net_zero_tracker:CD FIH:2050,CD FIH,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:CI ABJ:2050,CI ABJ,Net zero,,2050,,,https://www.c40.org/cities/abidjan/,net_zero_tracker
+net_zero_tracker:CN BJS:2050,CN BJS,Net zero,,2050,,,,net_zero_tracker
+net_zero_tracker:CN CDU:2050,CN CDU,Net zero,,2050,,,https://news.bjx.com.cn/html/20220117/1199822.shtml,net_zero_tracker
+net_zero_tracker:CN DAL:2050,CN DAL,Net zero,,2050,,,https://climateaction.unfccc.int/Actors/Cities/GCAP19902,net_zero_tracker
+net_zero_tracker:CN FUZ:2060,CN FUZ,Climate neutral,,2060,,,https://www.fuzhou.gov.cn/zwgk/ghjh/zxgh/202205/P020220531364015290873.pdf,net_zero_tracker
+net_zero_tracker:CN FZH:2060,CN FZH,Climate neutral,,2060,,,https://www.fuzhou.gov.cn/zwgk/ghjh/zxgh/202205/P020220531364015290873.pdf,net_zero_tracker
+net_zero_tracker:CN HAZ:2060,CN HAZ,Climate neutral,,2060,,,https://www.hangzhou.gov.cn/art/2022/4/25/art_812262_59054527.html,net_zero_tracker
+net_zero_tracker:CN NHN:2060,CN NHN,Climate neutral,,2060,,,http://hbj.wuhan.gov.cn/fbjd_19/zc/zcjd/202204/t20220411_1953569.html,net_zero_tracker
+net_zero_tracker:CN NJI:2060,CN NJI,Climate neutral,,2060,,,http://www.xhby.net/ly/wltt/202205/t20220525_7556859.shtml,net_zero_tracker
+net_zero_tracker:CN QIN:2060,CN QIN,Climate neutral,,2060,,,https://huanbao.bjx.com.cn/news/20220407/1215889.shtml,net_zero_tracker
+net_zero_tracker:CN SNZ:2060,CN SNZ,Climate neutral,,2060,,,http://www.cnbayarea.org.cn/attachment/0/3/3527/448485.pdf,net_zero_tracker
+net_zero_tracker:CN ZZU:2060,CN ZZU,Climate neutral,,2060,,,https://www.fuzhou.gov.cn/zwgk/ghjh/zxgh/202205/P020220531364015290873.pdf,net_zero_tracker
+net_zero_tracker:CO BAQ:2050,CO BAQ,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:CO BOG:2050,CO BOG,Net zero,,2050,,,https://climateaction.unfccc.int/views/stakeholder-details.html?id=11180,net_zero_tracker
+net_zero_tracker:CR SJO:2050,CR SJO,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:CZ PRG:2050,CZ PRG,Net zero,,2050,,,https://klima.praha.eu/DATA/Dokumenty/Klimaplan_2109_15_online_LOWRES_final2.pdf,net_zero_tracker
+net_zero_tracker:DE BER:2045,DE BER,Climate neutral,,2045,,,https://gesetze.berlin.de/bsbe/document/jlr-EWendGBErahmen,net_zero_tracker
+net_zero_tracker:DE DTM:2050,DE DTM,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:DE EEN:2050,DE EEN,Net zero,,2050,,,"https://www.essen.de/leben/umwelt/luft/treibhausgas_bilanz.de.html#:~:text=August%202020%20per%20Ratsbeschluss%20nachgesch%C3%A4rft,2040%20um%2085%20%25%20gegen%C3%BCber%201990.",net_zero_tracker
+net_zero_tracker:DE ESS:2050,DE ESS,Net zero,,2050,,,"https://www.essen.de/leben/umwelt/luft/treibhausgas_bilanz.de.html#:~:text=August%202020%20per%20Ratsbeschluss%20nachgesch%C3%A4rft,2040%20um%2085%20%25%20gegen%C3%BCber%201990.",net_zero_tracker
+net_zero_tracker:DE HAM:2050,DE HAM,Climate neutral,,2050,,,https://www.hamburg.de/contentblob/13899086/749a6e50662c96eee81d370f1b0cb631/data/d-first-revision-hamburg-climate-plan.pdf,net_zero_tracker
+net_zero_tracker:DE ONU:2050,DE ONU,Net zero,,2050,,,"https://www.essen.de/leben/umwelt/luft/treibhausgas_bilanz.de.html#:~:text=August%202020%20per%20Ratsbeschluss%20nachgesch%C3%A4rft,2040%20um%2085%20%25%20gegen%C3%BCber%201990.",net_zero_tracker
+net_zero_tracker:DE STR:2050,DE STR,Climate neutral,,2050,,,https://www.stuttgart.de/leben/umwelt/energie/,net_zero_tracker
+net_zero_tracker:EC GYE:2050,EC GYE,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:EC UIO:2050,EC UIO,Climate neutral,,2050,,,http://www.quitoambiente.gob.ec/images/Secretaria_Ambiente/Cambio_Climatico/plan_accion_climatico_quito_2020/Folleto%20Resumen%20PACQ01_mar_21.pdf,net_zero_tracker
+net_zero_tracker:ES BCN:2050,ES BCN,Climate neutral,,2050,,,https://www.barcelona.cat/barcelona-pel-clima/sites/default/files/documents/climate_plan_maig.pdf,net_zero_tracker
+net_zero_tracker:ES MAD:2050,ES MAD,Climate neutral,,2050,,,https://www.madrid.es/UnidadesDescentralizadas/Sostenibilidad/EspeInf/EnergiayCC/06Divulgaci%C3%B3n/6cDocumentacion/6cNHRNeutral/Ficheros/RoadmapENG.pdf,net_zero_tracker
+net_zero_tracker:ES VLC:2050,ES VLC,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:ET ADD:2050,ET ADD,Net zero,,2050,,,https://addisenviroment.gov.et/wp-content/uploads/2021/10/C-40-September-14-compressed.pdf,net_zero_tracker
+net_zero_tracker:FR BOD:2050,FR BOD,Net zero,,2050,,,https://en.calameo.com/read/0014801211e68b0f697d0,net_zero_tracker
+net_zero_tracker:FR GNB:2050,FR GNB,Climate neutral,,2050,,,https://www.grenoblealpesmetropole.fr/cms_viewFile.php?idtf=7126&path=Strategie-et-plan-d-actions.pdf,net_zero_tracker
+net_zero_tracker:FR NTE:2050,FR NTE,Net zero,,2050,,,https://metropole.nantes.fr/territoire-institutions/projet/ambitions-territoire/33-engagements-pour-la-transitio,net_zero_tracker
+net_zero_tracker:FR PAR:2050,FR PAR,Net zero,,2050,,,"https://www.c40knowledgehub.org/s/article/Paris-Climate-Action-Plan-Towards-a-carbon-neutral-city-and-100-renewable-energy?language=en_US#:~:text=By%202030%2C%20an%20operational%20action,100%25%20reliant%20on%20renewable%20energy.",net_zero_tracker
+net_zero_tracker:GB BOH:2050,GB BOH,Climate neutral,,2050,,,https://democracy.bcpcouncil.gov.uk/documents/s21606/Climate%20Action%20Annual%20Report%202019%2020%2016122020%20Cabinet.pdf,net_zero_tracker
+net_zero_tracker:GB BRS:2030,GB BRS,GHG neural,,2030,,,https://www.bristolonecity.com/wp-content/uploads/2020/02/one-city-climate-strategy.pdf,net_zero_tracker
+net_zero_tracker:GB EDI:2030,GB EDI,Net zero,,2030,,,https://www.edinburgh.gov.uk/downloads/download/15068/2030-climate-strategy,net_zero_tracker
+net_zero_tracker:GB GLW:2030,GB GLW,Net zero,,2030,,,https://www.glasgow.gov.uk/CHttpHandler.ashx?id=50623&p=0,net_zero_tracker
+net_zero_tracker:GB LIV:2030,GB LIV,Net zero,,2030,,,https://liverpool.gov.uk/media/1361340/liverpool_action_plan_full_final_digi.pdf,net_zero_tracker
+net_zero_tracker:GB MNC:2038,GB MNC,Climate neutral,,2038,,,https://www.manchesterclimate.com/sites/default/files/Manchester%20Climate%20Change%20Framework%202020-25.pdf,net_zero_tracker
+net_zero_tracker:GB NCS:2030,GB NCS,Net zero,,2030,,,https://www.newcastle.gov.uk/sites/default/files/Climate%20Change/Net%20Zero/Net%20Zero%20Newcastle%20-%202030%20Action%20Plan_0.pdf,net_zero_tracker
+net_zero_tracker:GB NTG:2028,GB NTG,Climate neutral,,2028,,,https://www.nottinghamcity.gov.uk/media/2619917/2028-carbon-neutral-action-plan-v2-160620.pdf,net_zero_tracker
+net_zero_tracker:GB SHE:2030,GB SHE,Net zero,,2030,,,https://www.sheffield.gov.uk/sites/default/files/2022-10/city-level-decarbonisation-pathways-sheffield.pdf,net_zero_tracker
+net_zero_tracker:GB SOU:2030,GB SOU,Net zero,,2030,,,https://www.southampton.gov.uk/our-green-city/climate-change/zero-carbon-challenge/,net_zero_tracker
+net_zero_tracker:GH ACC:2050,GH ACC,Net zero,,2050,,,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5ab410faa2f42204838f7990/5ab5605ea2f4220acf45cfa6/files/Accra_Climate_Action_Plan.pdf?1603293785,net_zero_tracker
+net_zero_tracker:HK HKG:2050,HK HKG,Climate neutral,,2050,,,https://www.climateready.gov.hk/files/pdf/CAP2050_booklet_en.pdf,net_zero_tracker
+net_zero_tracker:HU BUD:2050,HU BUD,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:IN BLR:2050,IN BLR,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:IN GWL:2050,IN GWL,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:IN ICD:2050,IN ICD,Net zero,,2050,,,https://www.ren21.net/wp-content/uploads/2019/05/REN21_Cities2021_Fact-Sheet_India.pdf,net_zero_tracker
+net_zero_tracker:IN IDR:2050,IN IDR,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:IN NAG:2040,IN NAG,Net zero,,2040,,,"https://www.hindustantimes.com/cities/mumbai-news/43-maharashtra-cities-to-join-global-race-to-zero-campaign-101632416518498.html#:~:text=Cities%20joining%20this%20campaign%20have,Osmanabad%20and%20Latur%20among%20others.",net_zero_tracker
+net_zero_tracker:IN STV:2050,IN STV,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:JO AMM:2050,JO AMM,Net zero,,2050,,,https://www.amman.jo/site_doc/climate.pdf,net_zero_tracker
+net_zero_tracker:JP HMM:2050,JP HMM,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:JP KKJ:2050,JP KKJ,Net zero,,2050,,,https://www.city.kitakyushu.lg.jp/kankyou/00200196.html,net_zero_tracker
+net_zero_tracker:JP KWS:2050,JP KWS,Net zero,,2050,,,https://www.city.kawasaki.jp/300/page/0000121670.html,net_zero_tracker
+net_zero_tracker:JP MYJ:2050,JP MYJ,Net zero,,2050,,,https://www.city.matsuyama.ehime.jp/shisei/machizukuri/kankyoumodel/modelkeikaku.html,net_zero_tracker
+net_zero_tracker:JP SAK:2050,JP SAK,Climate neutral,,2050,,,https://www.city.sakai.lg.jp/shisei/gyosei/shishin/kankyo/torikumi/env_strat.html,net_zero_tracker
+net_zero_tracker:JP SGH:2050,JP SGH,Net zero,,2050,,,https://www.city.sagamihara.kanagawa.jp/kurashi/kankyo/plan/1023953/index.html,net_zero_tracker
+net_zero_tracker:JP SPK:2050,JP SPK,Net zero,,2050,,,https://www.city.sapporo.jp/kankyo/ondanka/kikouhendou_plan2020/index.html,net_zero_tracker
+net_zero_tracker:JP UKB:2050,JP UKB,Net zero,,2050,,,https://www.city.kobe.lg.jp/documents/4411/20201209_2050zero.pdf,net_zero_tracker
+net_zero_tracker:JP YOK:2050,JP YOK,Net zero,,2050,,,https://www.city.yokohama.lg.jp/kurashi/machizukuri-kankyo/ondanka/jikkou/,net_zero_tracker
+net_zero_tracker:KE NBO:2050,KE NBO,Net zero,,2050,,,https://cdn.nation.co.ke/downloads/Nairobi-City-Climate-Action-2021.pdf,net_zero_tracker
+net_zero_tracker:KR ANY:2050,KR ANY,Climate neutral,,2050,,,https://www.mois.go.kr/cmm/fms/FileDown.do?atchFileId=FILE_00101190L1_eLCh&fileSn=0,net_zero_tracker
+net_zero_tracker:KR ASN:2050,KR ASN,Climate neutral,,2050,,,https://www.mois.go.kr/cmm/fms/FileDown.do?atchFileId=FILE_00101190L1_eLCh&fileSn=0,net_zero_tracker
+net_zero_tracker:KR CHW:2050,KR CHW,Climate neutral,,2050,,,https://www.mois.go.kr/cmm/fms/FileDown.do?atchFileId=FILE_00101190L1_eLCh&fileSn=0,net_zero_tracker
+net_zero_tracker:KR INC:2050,KR INC,Climate neutral,,2050,,,https://www.mois.go.kr/cmm/fms/FileDown.do?atchFileId=FILE_00101190L1_eLCh&fileSn=0,net_zero_tracker
+net_zero_tracker:KR JNJ:2050,KR JNJ,Climate neutral,,2050,,,https://www.mois.go.kr/cmm/fms/FileDown.do?atchFileId=FILE_00101190L1_eLCh&fileSn=0,net_zero_tracker
+net_zero_tracker:KR KWJ:2050,KR KWJ,Climate neutral,,2050,,,https://www.mois.go.kr/cmm/fms/FileDown.do?atchFileId=FILE_00101190L1_eLCh&fileSn=0,net_zero_tracker
+net_zero_tracker:KR KWU:2050,KR KWU,Climate neutral,,2050,,,https://www.mois.go.kr/cmm/fms/FileDown.do?atchFileId=FILE_00101190L1_eLCh&fileSn=0,net_zero_tracker
+net_zero_tracker:KR SEL:2050,KR SEL,Net zero,,2050,,,https://www.si.re.kr/si_download/63602/27895,net_zero_tracker
+net_zero_tracker:KR TAE:2050,KR TAE,Climate neutral,,2050,,,https://www.mois.go.kr/cmm/fms/FileDown.do?atchFileId=FILE_00101190L1_eLCh&fileSn=0,net_zero_tracker
+net_zero_tracker:KR USN:2050,KR USN,Climate neutral,,2050,,,https://www.mois.go.kr/cmm/fms/FileDown.do?atchFileId=FILE_00101190L1_eLCh&fileSn=0,net_zero_tracker
+net_zero_tracker:LV RIX:2050,LV RIX,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:MA RBA:2050,MA RBA,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:MX GDL:2050,MX GDL,Climate neutral,,2050,,,https://transparencia.info.jalisco.gob.mx/sites/default/files/Plan%20de%20acci%C3%B3n%20clim%C3%A1tica.pdf,net_zero_tracker
+net_zero_tracker:MX SLW:2050,MX SLW,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:MY KUL:2050,MY KUL,Net zero,,2050,,,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5ab410faa2f42204838f7990/5b4e04e374782004ac0c8ac2/files/C40_KLCAP2050_viewing-only-MR-single.pdf?1626096224,net_zero_tracker
+net_zero_tracker:NG LOS:2050,NG LOS,Net zero,,2050,,,https://moelagos.gov.ng/wp-content/uploads/2021/09/C40-Lagos_Indesign-Document-Full-Report-Revert-2_Update-2.pdf,net_zero_tracker
+net_zero_tracker:NL AMS:2050,NL AMS,Climate neutral,,2050,,,https://www.amsterdam.nl/en/policy/sustainability/policy-climate-neutrality/,net_zero_tracker
+net_zero_tracker:NL RTM:2050,NL RTM,Climate neutral,,2050,,,https://www.010duurzamestad.nl/wat-wij-doen/Rotterdamse-klimaataanpak-mei-2019.pdf,net_zero_tracker
+net_zero_tracker:NZ AKL:2050,NZ AKL,Net zero,,2050,,,https://www.aucklandcouncil.govt.nz/plans-projects-policies-reports-bylaws/our-plans-strategies/topic-based-plans-strategies/environmental-plans-strategies/aucklands-climate-plan/Documents/auckland-climate-plan.pdf,net_zero_tracker
+net_zero_tracker:PE LIM:2050,PE LIM,Net zero,,2050,,,https://cop25.mma.gob.cl/wp-content/uploads/2020/02/Annex-Alliance-ENGLISH.pdf,net_zero_tracker
+net_zero_tracker:PL WRO:2050,PL WRO,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:RW KGL:2050,RW KGL,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:SN DKR:2050,SN DKR,Net zero,,2050,,,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5c8ab5851647e100801756a3/60dadeb05761d600a57c9345/files/C40_Dakar_English_Final.pdf?1624956592,net_zero_tracker
+net_zero_tracker:TR AYT:2050,TR AYT,Net zero,,2050,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:TR IST:2053,TR IST,Net zero,,2053,,,https://unfccc.int/climate-action/race-to-zero/who-s-in-race-to-zero#eq-5,net_zero_tracker
+net_zero_tracker:TR IZM:2050,TR IZM,Net zero,,2050,,,,net_zero_tracker
+net_zero_tracker:TW TNN:2050,TW TNN,Net zero,,2050,,,https://www.tainan.gov.tw/en/News_Content.aspx?n=13205&sms=13686&s=7768548,net_zero_tracker
+net_zero_tracker:TZ DAR:2050,TZ DAR,Net zero,,2050,,,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5c8ab5851647e100801756a3/623af4b0bf8bcc8b7c5a7d76/files/Dar_CAP_English_Version_Final_16_Dec_2021.pdf?1648030896,net_zero_tracker
+net_zero_tracker:UG KLA:2050,UG KLA,Net zero,,2050,,,https://www.kcca.go.ug/uDocs/Kampala-Climate-Change-Action.pdf,net_zero_tracker
+net_zero_tracker:VN HAN:2050,VN HAN,Net zero,,2050,,,https://en.vietnamplus.vn/hanoi-aims-to-reduce-greenhouse-gas-emissions/191063.vnp,net_zero_tracker
+net_zero_tracker:ZA CPT:2050,ZA CPT,Climate neutral,,2050,,,https://resource.capetown.gov.za/documentcentre/Documents/City%20strategies%2C%20plans%20and%20frameworks/CCT_Climate_Change_Action_Plan.pdf,net_zero_tracker
+net_zero_tracker:ZA DUR:2050,ZA DUR,Climate neutral,,2050,,,https://tinyurl.com/2zdlc28c,net_zero_tracker
+net_zero_tracker:ZA JNB:2050,ZA JNB,Net zero,,2050,,,https://cdn.locomotive.works/sites/5ab410c8a2f42204838f797e/content_entry5ab410faa2f42204838f7990/5ab5614aa2f4220acf45cfb8/files/City_of_Johannesburg_-_CAP-lores-compressed.pdf?1623066563,net_zero_tracker
+net_zero_tracker:ZA PRY:2050,ZA PRY,Net zero,,2050,,,https://www.tshwane.gov.za/sites/Council/Ofiice-Of-The-Executive-Mayor/Climate%20Action/CAP_EXECUTIVE%20SUMMARY%20REPORT%20no%20marks.pdf,net_zero_tracker
+net_zero_tracker:ZM LUN:2050,ZM LUN,Net zero,,2050,,,,net_zero_tracker
+net_zero_tracker:029200268F8M5YI5I629:2050,029200268F8M5YI5I629,Net zero,,2050,,,https://www.zenithbank.com/media/3460/zb-2021-annual-report.pdf,net_zero_tracker
+net_zero_tracker:08IRJODWFYBI7QWRGS31:2050,08IRJODWFYBI7QWRGS31,Net zero,,2050,,,https://www.weyerhaeuser.com/sustainability/3by30/climate-change-solutions/,net_zero_tracker
+net_zero_tracker:0BGI85ALH27ZJP15DY16:2050,0BGI85ALH27ZJP15DY16,Net zero,,2050,,,https://www.ball.com/na/vision/sustainability/operational-excellence/ghg-emissions,net_zero_tracker
+net_zero_tracker:0EEB8GF0W0NPCIHZX097:2040,0EEB8GF0W0NPCIHZX097,Net zero,,2040,,,https://publications.aecom.com/sustainable-legacies/achieve-net-zero-carbon-emissions,net_zero_tracker
+net_zero_tracker:0J0XRGZE3PBRFEZ7MV65:2035,0J0XRGZE3PBRFEZ7MV65,Climate neutral,,2035,,,https://corporate.charter.com/esg-report.pdf,net_zero_tracker
+net_zero_tracker:1B4S6S7G0TW5EE83BO58:2050,1B4S6S7G0TW5EE83BO58,Net zero,,2050,,,https://www.aepsustainability.com/performance/report/docs/2022_AEP-Sustainability-Report.pdf,net_zero_tracker
+net_zero_tracker:1Z4GXXU7ZHVWFCD8TV52:2050,1Z4GXXU7ZHVWFCD8TV52,Net zero,,2050,,,https://www.oracle.com/assets/ccr-datasheet-3855392.pdf,net_zero_tracker
+net_zero_tracker:20S05OYHG0MQM4VUIC57:2050,20S05OYHG0MQM4VUIC57,Climate neutral,,2050,,,https://corporate.ford.com/microsites/integrated-sustainability-and-financial-report-2021/files/ir21.pdf,net_zero_tracker
+net_zero_tracker:2138001AVBSD1HSC6Z10:2040,2138001AVBSD1HSC6Z10,Net zero,,2040,,,https://matthey.com/en/news/2021/btc-opening,net_zero_tracker
+net_zero_tracker:2138001P49OLAEU33T68:2050,2138001P49OLAEU33T68,Net zero,,2050,,,https://www.thephoenixgroup.com/corporate-responsibility/environment.aspx,net_zero_tracker
+net_zero_tracker:2138002P5RNKC5W2JZ46:2050,2138002P5RNKC5W2JZ46,Net zero,,2050,,,https://www.tescoplc.com/news/2020/from-solar-farms-to-electric-delivery-fleets-tesco-takes-action-to-hit-net-zero-in-uk-by-2035/,net_zero_tracker
+net_zero_tracker:21380044BQ8812EEKT59:2022,21380044BQ8812EEKT59,Climate neutral,,2022,,,https://presspage-production-content.s3.amazonaws.com/uploads/2659/naspers-mapping-our-environmental-footprint.pdf?10000,net_zero_tracker
+net_zero_tracker:2138004KW8BV57III342:2030,2138004KW8BV57III342,Climate neutral,,2030,,,https://rse2019.publicisgroupe.com/en/environnement,net_zero_tracker
+net_zero_tracker:2138006R85VEOF5YNK29:2040,2138006R85VEOF5YNK29,Net zero,,2040,,,https://www.barrattdevelopments.co.uk/media/media-releases/pr-2020/pr-29-06-20,net_zero_tracker
+net_zero_tracker:2138007Z3U5GWDN3MY22:2019,2138007Z3U5GWDN3MY22,Net zero,,2019,,,https://www.investec.com/content/dam/international/corporate-responsibility/corporate-sustainability-report/Investec-2020-Climate-Related-Financial-Disclosures-final.pdf,net_zero_tracker
+net_zero_tracker:213800FKA5MF17RJKT63:2050,213800FKA5MF17RJKT63,Net zero,,2050,,,https://www.bat.com/group/sites/UK__9D9KCY.nsf/vwPagesWebLive/DOAWWEKR/$file/BAT_Low_Carbon_Transition_Plan_2022.pdf,net_zero_tracker
+net_zero_tracker:213800FSR9RNDUOTXO25:2050,213800FSR9RNDUOTXO25,Net zero,,2050,,,https://www.teliacompany.com/globalassets/telia-company/documents/reports/2020/annual/telia-company--annual-and-sustainability-report-2020.pdf,net_zero_tracker
+net_zero_tracker:213800KBMEV7I92FY281:2050,213800KBMEV7I92FY281,Net zero,,2050,,,https://www.kingfisher.com/en/media/news/kingfisher-news/2021/kingfisher-plc-announces-new-2025-carbon-reduction-targets---app.html,net_zero_tracker
+net_zero_tracker:213800LBQA1Y9L22JB70:2050,213800LBQA1Y9L22JB70,Net zero,,2050,,,https://home.barclays/content/dam/home-barclays/documents/citizenship/ESG/Barclays-PLC-Climate-Change-2020.pdf,net_zero_tracker
+net_zero_tracker:213800LH1BZH3DI6G760:2050,213800LH1BZH3DI6G760,Net zero,,2050,,,https://www.bp.com/content/dam/bp/business-sites/en/global/corporate/pdfs/sustainability/group-reports/bp-sustainability-report-2020.pdf,net_zero_tracker
+net_zero_tracker:213800LOZA69QFDC9N34:2050,213800LOZA69QFDC9N34,Net zero,,2050,,,https://www.mondigroup.com/en/sustainability/sustainability-reports-and-publications/,net_zero_tracker
+net_zero_tracker:213800MY6QVH4FVLD628:2050,213800MY6QVH4FVLD628,Climate neutral,,2050,,,https://www.antofagasta.co.uk/investors/news/2021/antofagasta-sets-new-emissions-targets/,net_zero_tracker
+net_zero_tracker:213800TCZZU84G8Z2M70:2040,213800TCZZU84G8Z2M70,Net zero,,2040,,,https://www.royalmail.com/sustainability/environment/net-zero,net_zero_tracker
+net_zero_tracker:213800WFQ334R8UXUG83:2050,213800WFQ334R8UXUG83,Net zero,,2050,,,https://www.vinci.com/publi/vinci/extract/2021_annual_report_extract-sustainability.pdf,net_zero_tracker
+net_zero_tracker:213800X3Q9LSAKRUWY91:2050,213800X3Q9LSAKRUWY91,Net zero,,2050,,,https://www.kbc.com/en/corporate-sustainability/limiting-our-adverse-impact/our-own-environmental-footprint.html,net_zero_tracker
+net_zero_tracker:213800XC35KGM9NFC641:2030,213800XC35KGM9NFC641,Net zero,,2030,,,https://www.segro.com/responsible-segro/carbon,net_zero_tracker
+net_zero_tracker:213800YOEO5OQ72G2R82:2050,213800YOEO5OQ72G2R82,Net zero,,2050,,,https://www.riotinto.com/-/media/Content/Documents/Invest/Reports/Climate-Change-reports/RT-climate-report-2020.pdf?rev=c415a8138bd7408496ccb3834511abc0,net_zero_tracker
+net_zero_tracker:213800ZVIELEA55JMJ32:2030,213800ZVIELEA55JMJ32,Net zero,,2030,,,https://www.esgtoday.com/diageo-climate-goals-approved-by-science-based-targets-initiative-as-in-line-with-1-5c/,net_zero_tracker
+net_zero_tracker:25490005ZWM1IF9UXU57:2050,25490005ZWM1IF9UXU57,Net zero,,2050,,,https://biz.dominos.com/stewardship/environmental-footprint/,net_zero_tracker
+net_zero_tracker:2549003PEZXUT7MDBU41:2050,2549003PEZXUT7MDBU41,Net zero,,2050,,,https://www.standardbank.com/static_file/StandardBankGroup/filedownloads/Climate%20Strategy/SBGClimatePolicy_March2022.pdf,net_zero_tracker
+net_zero_tracker:254900CEKKWIHTEAB172:2050,254900CEKKWIHTEAB172,Net zero,,2050,,,https://www.visitwynn.com/documents/2020_ESG_Report_Wynn_Resorts.pdf,net_zero_tracker
+net_zero_tracker:254900GE1G59KGWPHX32:2030,254900GE1G59KGWPHX32,Net zero,,2030,,,https://holdings.panasonic/global/corporate/sustainability/pdf/sdb2021e.pdf,net_zero_tracker
+net_zero_tracker:254900QJ68UH8GKNGI69:2022,254900QJ68UH8GKNGI69,Climate neutral,,2022,,,https://www.ayalaland.com.ph/ayala-land-now-91-carbon-neutral-on-track-for-zero-footprint-in-2022/,net_zero_tracker
+net_zero_tracker:254900TWUJUQ44TQJY84:2050,254900TWUJUQ44TQJY84,Net zero,,2050,,,https://www.mandgplc.com/~/media/Files/M/MandG-Plc/documents/responsible-investing/climate-change/MG-approach-to-climate-change_0420.pdf,net_zero_tracker
+net_zero_tracker:2572IBTT8CCZW6AU4141:2040,2572IBTT8CCZW6AU4141,Net zero,,2040,,,https://www.pginvestor.com/esg/environmental/climate/default.aspx,net_zero_tracker
+net_zero_tracker:2NUNNB7D43COUIRE5295:2050,2NUNNB7D43COUIRE5295,Net zero,,2050,,,https://www.aes.com/aes-vision-net-zero-carbon-future-and-how-were-getting-there,net_zero_tracker
+net_zero_tracker:2S72QS2UO2OESLG6Y829:2035,2S72QS2UO2OESLG6Y829,Net zero,,2035,,,https://www.verizon.com/about/news/verizon-environmental-initiatives-reduce-global-climate-impact,net_zero_tracker
+net_zero_tracker:2TGYMUGI08PO8X8L6150:2050,2TGYMUGI08PO8X8L6150,Net zero,,2050,,,https://www.generalmills.com/en/Responsibility/Sustainability/climate-change,net_zero_tracker
+net_zero_tracker:2W8N8UU78PMDQKZENC08:2037,2W8N8UU78PMDQKZENC08,Net zero,,2037,,,https://group.intesasanpaolo.com/content/dam/portalgroup/repository-documenti/investor-relations/bilanci-relazioni-en/2021/2021_Annual__report.pdf,net_zero_tracker
+net_zero_tracker:35380000WKGEAHEMW830:2050,35380000WKGEAHEMW830,Climate neutral,,2050,,,https://www.toyota-industries.com/investors/items/TICO%20Report%202021_EN_full_view.pdf,net_zero_tracker
+net_zero_tracker:3538000246DHJLRTUZ24:2050,3538000246DHJLRTUZ24,Net zero,,2050,,,https://www.fujitsu.com/global/documents/about/resources/reports/sustainabilityreport/2018-report/fujitsureport201801-e.pdf,net_zero_tracker
+net_zero_tracker:3538001KQ5SAOZSQTT44:2045,3538001KQ5SAOZSQTT44,Net zero,,2045,,,"https://www.engieimpact.com/insights/decarbonization-energy-sector#:~:text=In%20May%202021%2C%20ENGIE%20announced,emissions%20across%20its%20value%20chain.&text=This%20long%2Dterm%20ambition%20is,well%20below%202%C2%B0C.",net_zero_tracker
+net_zero_tracker:3538001KQ5SAOZSQTT44:2050,3538001KQ5SAOZSQTT44,Net zero,,2050,,,https://fpcj.jp/wp/wp-content/uploads/2020/07/79d1e6a5a2e7a4888ca9d3f1f7a07033.pdf,net_zero_tracker
+net_zero_tracker:3538002347FGLMNPVY63:2050,3538002347FGLMNPVY63,Net zero,,2050,,,https://s23.q4cdn.com/685814098/files/doc_downloads/sustainability/2021/KLGold_GSR_Design_13.pdf,net_zero_tracker
+net_zero_tracker:35380028MYWPB6AUO129:2050,35380028MYWPB6AUO129,Net zero,,2050,,,https://www.smfg.co.jp/english/sustainability/common/pdf/2021/2021SustainabilityReportEN_all.pdf,net_zero_tracker
+net_zero_tracker:3538002MH5L1QZZ93477:2050,3538002MH5L1QZZ93477,Net zero,,2050,,,https://www.jal.com/en/sustainability/environment/climate-action/#initiative,net_zero_tracker
+net_zero_tracker:3538002NUIQ8JFEJNS94:2050,3538002NUIQ8JFEJNS94,Net zero,,2050,,,https://www.shigagin.com/pdf/investor_anuual_ar2021_all.pdf,net_zero_tracker
+net_zero_tracker:3538004IOK08PDY6I723:2050,3538004IOK08PDY6I723,Climate neutral,,2050,,,https://www.aisin.com/en/sustainability/report/pdf/aisin_ar2021_en_a4.pdf,net_zero_tracker
+net_zero_tracker:3538004LR5NXILJDHY88:2050,3538004LR5NXILJDHY88,Net zero,,2050,,,https://global.yamaha-motor.com/about/csr/the_environment/plan-2050/#sec-01-07,net_zero_tracker
+net_zero_tracker:35380099TCYR5FHT0A11:2050,35380099TCYR5FHT0A11,Net zero,,2050,,,https://www.toray.com/global/sustainability/tcfd/pdf/TCFD_report.pdf,net_zero_tracker
+net_zero_tracker:353800BRAE0QFP3ZLY22:2050,353800BRAE0QFP3ZLY22,Net zero,,2050,,,https://www.shimz.co.jp/en/company/csr/environment/performance/eco/,net_zero_tracker
+net_zero_tracker:353800CWW4SRGEYEB512:2050,353800CWW4SRGEYEB512,Net zero,,2050,,,https://www.sompo-hd.com/-/media/hd/en/files/csr/communications/pdf/2021/e_report2021.pdf?la=ja-JP,net_zero_tracker
+net_zero_tracker:353800DRBDH1LUTNAY26:2050,353800DRBDH1LUTNAY26,Climate neutral,,2050,,,https://www.nissan-global.com/EN/DOCUMENT/PDF/SR/2021/SR21_E_All.pdf,net_zero_tracker
+net_zero_tracker:353800EMK32PDKS9XR54:2050,353800EMK32PDKS9XR54,Net zero,,2050,,,https://www.advantest.com/sustainability/pdf/E_all_IAR2020.pdf,net_zero_tracker
+net_zero_tracker:353800GBVL72LLMTYM96:2050,353800GBVL72LLMTYM96,Net zero,,2050,,,https://www.kirinholdings.co.jp/english/csv/env/climatechange.html,net_zero_tracker
+net_zero_tracker:353800GPI4Z3MGDGN142:2050,353800GPI4Z3MGDGN142,Climate neutral,,2050,,,https://www.asahi-kasei.com/news/2021/e210525_2.html,net_zero_tracker
+net_zero_tracker:353800HDEE0ZYEX4QV91:2040,353800HDEE0ZYEX4QV91,Climate neutral,,2040,,,https://www.eisai.com/ir/library/annual/pdf/epdf2020er.pdf,net_zero_tracker
+net_zero_tracker:353800KTF7EYIIYHY088:2050,353800KTF7EYIIYHY088,Climate neutral,,2050,,,https://www.tohoku-epco.co.jp/ir/report/integrated_report/pdf/tohoku_report2021en.pdf,net_zero_tracker
+net_zero_tracker:353800MV866ELME96Q46:2050,353800MV866ELME96Q46,Climate neutral,,2050,,,https://www.energia.co.jp/e/index.html,net_zero_tracker
+net_zero_tracker:353800ND4ZKNZDYKMF33:2050,353800ND4ZKNZDYKMF33,Net zero,,2050,,,https://www.mitsuifudosan.co.jp/english/corporate/esg_csr/environment/05.html,net_zero_tracker
+net_zero_tracker:353800P843RLCDBLNT17:2050,353800P843RLCDBLNT17,Net zero,,2050,,,https://www.smth.jp/english/-/media/th/english/news/2021/E211020.pdf,net_zero_tracker
+net_zero_tracker:353800P8O843TMAZ6S09:2050,353800P8O843TMAZ6S09,Climate neutral,,2050,,,https://jp.mitsuichemicals.com/en/sustainability/mci_sustainability/climate_change/carbon_neutrality.htm,net_zero_tracker
+net_zero_tracker:353800PFUKP5ONPJNZ86:2050,353800PFUKP5ONPJNZ86,Net zero,,2050,,,https://www.kepco.co.jp/english/csr/,net_zero_tracker
+net_zero_tracker:353800PX8Q64N86H5W41:2050,353800PX8Q64N86H5W41,Climate neutral,,2050,,,https://www.shinetsu.co.jp/en/sustainability/assets/pdf/sustainability/esg_bn/Sustainability2021E.pdf,net_zero_tracker
+net_zero_tracker:353800SENYJ2DSM6PS44:2051,353800SENYJ2DSM6PS44,Net zero,,2051,,,https://www.jreast.co.jp/e/environment/pdf_2020/all.pdf,net_zero_tracker
+net_zero_tracker:353800V2V8PUY9TK3E06:2050,353800V2V8PUY9TK3E06,Net zero,,2050,,,https://www.mufg.jp/english/csr/environment/cnd/index.html,net_zero_tracker
+net_zero_tracker:353800VHYYADPR6MXQ47:2050,353800VHYYADPR6MXQ47,Net zero,,2050,,,https://www.inpex.co.jp/english/csr/climatechange/,net_zero_tracker
+net_zero_tracker:353800W25FCOFE32EM73:2050,353800W25FCOFE32EM73,Net zero,,2050,,,https://www.asahigroup-holdings.com/en/csr/environment/climatechange.html,net_zero_tracker
+net_zero_tracker:353800Y4GZ7KR5X7L150:2050,353800Y4GZ7KR5X7L150,Net zero,,2050,,,https://ceh.cosmo-oil.co.jp/eng/ir/report/pdf/2021/report2021_en_05.pdf,net_zero_tracker
+net_zero_tracker:353800YEPK9PD7QO3449:2050,353800YEPK9PD7QO3449,Net zero,,2050,,,https://global.sharp/corporate/eco/environment/climate_change/#anc01,net_zero_tracker
+net_zero_tracker:353800YNKX4RQUGAR072:2050,353800YNKX4RQUGAR072,Net zero,,2050,,,https://www.mitsubishichem-hd.co.jp/english/news_release/01139.html,net_zero_tracker
+net_zero_tracker:353800Z0ENYBQO0XRJ31:2030,353800Z0ENYBQO0XRJ31,Net zero,,2030,,,https://www.ukrb-jti.com/jti-sustainability-environment.html,net_zero_tracker
+net_zero_tracker:378900F4544561A97588:2050,378900F4544561A97588,Net zero,,2050,,,"https://www.sasol.com/media-centre/media-releases/sasols-commitment-decarbonisation-reaffirmed-overwhelming-shareholder-support-climate-action#:~:text=Sasol%20committed%20to%20a%202050,Energy%20and%20Chemicals%20business%20units.",net_zero_tracker
+net_zero_tracker:3E70L4WYANTIWWIPHC81:2050,3E70L4WYANTIWWIPHC81,Net zero,,2050,,,https://tinyurl.com/2ktzzy7p,net_zero_tracker
+net_zero_tracker:3SOUA6IRML7435B56G12:2025,3SOUA6IRML7435B56G12,Net zero,,2025,,,https://www.exor.com/sites/default/files/2022/page-documents/Exor%202021%20Sustainability%20Report.pdf,net_zero_tracker
+net_zero_tracker:3SOUA6IRML7435B56G12:2050,3SOUA6IRML7435B56G12,Net zero,,2050,,,https://www.exeloncorp.com/newsroom/exelon-utilities-announces-goal-to-achieve-net-zero-emissions-by-2050,net_zero_tracker
+net_zero_tracker:4DR1VPDQMHD3N3QW8W95:2050,4DR1VPDQMHD3N3QW8W95,Climate neutral,,2050,,,https://carnival-sustainability-2022.nyc3.digitaloceanspaces.com/assets/content/pdf/FY-2021-Sustainability-Report_Carnival-Corporation-and-plc.pdf,net_zero_tracker
+net_zero_tracker:4P4N3ORD02UGQT1T1W12:2050,4P4N3ORD02UGQT1T1W12,Net zero,,2050,,,https://www.marubeni.com/en/news/2021/release/00022.html,net_zero_tracker
+net_zero_tracker:5299000D93LTLU0UJR35:2050,5299000D93LTLU0UJR35,Net zero,,2050,,,https://corporate.amp.com.au/content/dam/corporate/shareholdercentre/files/reports/2021/MARCH/210310_AMP_Sustainability_Report.pdf,net_zero_tracker
+net_zero_tracker:5299000Y52IFDI1I2A21:2050,5299000Y52IFDI1I2A21,Net zero,,2050,,,"https://www.engineeringnews.co.za/article/old-mutual-joins-net-zero-asset-owner-alliance-2022-03-11/rep_id:4136#:~:text=Old%20Mutual%20is%20one%20of%20the%20first%20asset,global%20warming%20to%201.5%20%CB%9AC%20above%20preindustrial%20levels.",net_zero_tracker
+net_zero_tracker:52990016II9MJ2OSWA10:2040,52990016II9MJ2OSWA10,Net zero,,2040,,,https://www.cbre.com/-/media/project/cbre/dotcom/global/about/corporate-responsibility/cbre-2020-corporate-responsibility-report.pdf,net_zero_tracker
+net_zero_tracker:5299001GRRO0Z25YZT52:2021,5299001GRRO0Z25YZT52,Climate neutral,,2021,,,https://www.knorr-bremse.com/en/responsibility/,net_zero_tracker
+net_zero_tracker:5299001X9L42HXEBCZ51:2023,5299001X9L42HXEBCZ51,Net zero,,2023,,,https://www.ceconomy.de/en/sustainability/,net_zero_tracker
+net_zero_tracker:5299002D52YIP6DWMV49:2051,5299002D52YIP6DWMV49,Climate neutral,,2051,,,https://www.meiji.com/global/sustainability/caring_for_the_earth/climate_change/,net_zero_tracker
+net_zero_tracker:52990037G8JRM3TWGY86:2050,52990037G8JRM3TWGY86,Net zero,,2050,,,https://www.7andi.com/library/dbps_data/_template_/_res/en/csr/csrreport/2020/pdf/2020_all_01.pdf,net_zero_tracker
+net_zero_tracker:5299003D9N4JBS256X18:2050,5299003D9N4JBS256X18,Climate neutral,,2050,,,https://www.japanpost.jp/sustainability/environment/greenhouse_gas/#charge,net_zero_tracker
+net_zero_tracker:5299003FU7V4I45FU310:2050,5299003FU7V4I45FU310,Net zero,,2050,,,https://www.kddi.com/extlib/files/english/corporate/csr/csr_report/2021/pdf/report2021_en.pdf,net_zero_tracker
+net_zero_tracker:5299004EMJ3R4RVR5Y75:2050,5299004EMJ3R4RVR5Y75,Climate neutral,,2050,,,https://www.tepco.co.jp/en/hd/about/ir/library/integratedreport/index-e.html,net_zero_tracker
+net_zero_tracker:5299005A2ZEP6AP7KM81:2050,5299005A2ZEP6AP7KM81,Climate neutral,,2050,,,https://reports.vonovia.de/2020/sustainability-report/,net_zero_tracker
+net_zero_tracker:5299005F1HCVF4M4QN79:2050,5299005F1HCVF4M4QN79,Net zero,,2050,,,https://www.nri.com/en/sustainability/environment/policy,net_zero_tracker
+net_zero_tracker:5299006EQ03K3SSUYS12:2030,5299006EQ03K3SSUYS12,Net zero,,2030,,,https://www.merlinproperties.com/wp-content/uploads/2022/05/Pathway-to-Net-Zero-02_22-1.pdf,net_zero_tracker
+net_zero_tracker:5299006UDSEJCTTEJS30:2050,5299006UDSEJCTTEJS30,Net zero,,2050,,,https://www.verbund.com/-/media/verbund/ueber-verbund/verantwortung/umwelt/klimaschutz/verbund-climate-report-en.ashx?ori=1&la=en,net_zero_tracker
+net_zero_tracker:5299006ZIILJ6VJVSJ32:2050,5299006ZIILJ6VJVSJ32,Net zero,,2050,,,https://www.talanx.com/media/Files/talanx-gruppe/nachhaltigkeitsberichte/2021_talanx_sustainability_report_.pdf,net_zero_tracker
+net_zero_tracker:5299006ZTN6MO1N5BR16:2050,5299006ZTN6MO1N5BR16,GHG neural,,2050,,,https://mmc.disclosure.site/en/themes/92,net_zero_tracker
+net_zero_tracker:5299008QCD0YDT5OF506:2026,5299008QCD0YDT5OF506,Climate neutral,,2026,,,https://corp.shiseido.com/en/sustainability/pdf/2020.pdf,net_zero_tracker
+net_zero_tracker:52990097YFPX9J0H5D87:2050,52990097YFPX9J0H5D87,Net zero,,2050,,,https://www.pernod-ricard.com/sites/default/files/2021-09/PERNOD%20RICARD%20ANNUAL%20REPORT%20FY21.pdf,net_zero_tracker
+net_zero_tracker:5299009QN2NZ191KLS29:2021,5299009QN2NZ191KLS29,Climate neutral,,2021,,,https://www.tokiomarinehd.com/en/release_topics/release/k82ffv000000b55w-att/210826_E.pdf,net_zero_tracker
+net_zero_tracker:529900A76GOP0PGNHT63:2050,529900A76GOP0PGNHT63,Net zero,,2050,,,https://www.chuden.co.jp/english/resource/esg/environment/zeroemissions/zeroemissions_01.pdf,net_zero_tracker
+net_zero_tracker:529900A7YD9C0LLXM621:2050,529900A7YD9C0LLXM621,Climate neutral,,2050,,,https://www.continental.com/en/press/studies-publications/technology-dossiers/sustainability/carbon-neutrality/,net_zero_tracker
+net_zero_tracker:529900C0QSXVCC7AR494:2050,529900C0QSXVCC7AR494,Net zero,,2050,,,https://www.automotiveworld.com/news-releases/isuzu-announces-formulation-of-isuzu-environmental-vision-2050/,net_zero_tracker
+net_zero_tracker:529900C3EX1FZGE48X78:2021,529900C3EX1FZGE48X78,Climate neutral,,2021,,,https://www.deliveryhero.com/sustainability/,net_zero_tracker
+net_zero_tracker:529900CXROT5S2HMMP26:2050,529900CXROT5S2HMMP26,Net zero,,2050,,,https://www.ms-ad-hd.com/en/ir/library/disclosure/main/015/teaserItems2/0/link/1115_en.pdf,net_zero_tracker
+net_zero_tracker:529900D6BF99LW9R2E68:2030,529900D6BF99LW9R2E68,Net zero,,2030,,,https://news.sap.com/2022/01/accelerating-net-zero-commitment/,net_zero_tracker
+net_zero_tracker:529900EHPFPYHV6IQO98:2050,529900EHPFPYHV6IQO98,Net zero,,2050,,,https://www.holcim.com/our-co2-emissions-reduction,net_zero_tracker
+net_zero_tracker:529900F3AIQECS8ZSV61:2035,529900F3AIQECS8ZSV61,Climate neutral,,2035,,,https://www.umicore.com/en/newsroom/news/umicore-unveils-bold-sustainability-ambitions-and-commits-to-achieving-carbon-neutrality-by-2035/,net_zero_tracker
+net_zero_tracker:529900F60CID3NCZM330:2050,529900F60CID3NCZM330,Net zero,,2050,,,https://socialresponsibility.carmax.com/,net_zero_tracker
+net_zero_tracker:529900G3SW56SHYNPR95:2025,529900G3SW56SHYNPR95,Climate neutral,,2025,,,https://deutsche-boerse.com/dbg-de/media/pressemitteilungen/Deutsche-B-rse-will-bis-2025-netto-klimaneutral-werden-2653534,net_zero_tracker
+net_zero_tracker:529900G48RT4KWLC6C27:2040,529900G48RT4KWLC6C27,Net zero,,2040,,,https://newsroom.alaskaair.com/2021-04-21-Alaska-Airlines-commits-to-carbon-waste-and-water-goals-for-2025-announces-path-to-net-zero-by-2040,net_zero_tracker
+net_zero_tracker:529900GB7KCA94ACC940:2040,529900GB7KCA94ACC940,Climate neutral,,2040,,,https://www.rwe.com/-/media/RWE/documents/09-responsibility-and-sustainability/cr-reports/EN/cr-report-2021.pdf,net_zero_tracker
+net_zero_tracker:529900IB708DY2HBBB35:2050,529900IB708DY2HBBB35,Net zero,,2050,,,https://www.astellas.com/en/sustainability/measures-to-address-climate-change,net_zero_tracker
+net_zero_tracker:529900JH1GSC035SSP77:2050,529900JH1GSC035SSP77,Net zero,,2050,,,https://www.responsibilityreports.com/HostedData/ResponsibilityReportArchive/c/NYSE_CAJ_2021.pdf,net_zero_tracker
+net_zero_tracker:529900JI1GG6F7RKVI53:2050,529900JI1GG6F7RKVI53,Net zero,,2050,,,https://www.loreal-finance.com/eng/news-events/loreal-recognized-global-compact-lead-united-nations-and-steps-its-climate-action,net_zero_tracker
+net_zero_tracker:529900K9B0N5BT694847:2050,529900K9B0N5BT694847,Net zero,,2050,,,https://www.allianz.com/content/dam/onemarketing/azcom/Allianz_com/sustainability/documents/Allianz_Group_Sustainability_Report_2020-web.pdf,net_zero_tracker
+net_zero_tracker:529900LVC9GIIYUGE243:2050,529900LVC9GIIYUGE243,Net zero,,2050,,,https://ojiholdings.disclosure.site/en/themes/198/,net_zero_tracker
+net_zero_tracker:529900MUF4C20K50JS49:2030,529900MUF4C20K50JS49,Net zero,,2030,,,https://www.munichre.com/content/dam/munichre/contentlounge/website-pieces/documents/munich_re_sustainability_report_2021.pdf/_jcr_content/renditions/original./munich_re_sustainability_report_2021.pdf,net_zero_tracker
+net_zero_tracker:529900NNUPAGGOMPXZ31:2050,529900NNUPAGGOMPXZ31,Climate neutral,,2050,,,https://www.volkswagenag.com/presence/nachhaltigkeit/documents/sustainability-report/2021/focus-topics/220310_VW_NB21_Decarbonization_EN.pdf,net_zero_tracker
+net_zero_tracker:529900OAREIS0MOPTW25:2040,529900OAREIS0MOPTW25,Climate neutral,,2040,,,https://www.merckgroup.com/en/sustainability/environment.html,net_zero_tracker
+net_zero_tracker:529900PM64WH8AF1E917:2050,529900PM64WH8AF1E917,Climate neutral,,2050,,,https://www.basf.com/global/en/media/news-releases/2021/03/p-21-166.html,net_zero_tracker
+net_zero_tracker:529900PS9YW3YY29F326:2050,529900PS9YW3YY29F326,Net zero,,2050,,,https://www.swissre.com/dam/jcr:5863fbc4-b708-4e61-acc7-6ef685461abb/swissre-sustainable-business-risk-framework.pdf,net_zero_tracker
+net_zero_tracker:529900Q0YED3805QXQ66:2050,529900Q0YED3805QXQ66,Net zero,,2050,,,https://home.kuehne-nagel.com/-/company/corporate-social-responsibility/carbon-offset,net_zero_tracker
+net_zero_tracker:529900QE24Q67I3FWZ10:2040,529900QE24Q67I3FWZ10,Climate neutral,,2040,,,https://www.deutsche-wohnen.com/en/about-us/press-news/press-releases/sustainability-report-2020,net_zero_tracker
+net_zero_tracker:529900QVNRBND50TXP03:2030,529900QVNRBND50TXP03,Net zero,,2030,,,https://www.zurich.com/en/sustainability/sustainable-operations/net-zero,net_zero_tracker
+net_zero_tracker:529900R27DL06UVNT076:2039,529900R27DL06UVNT076,Climate neutral,,2039,,,https://www.daimler.com/sustainability/climate/ambition-2039-our-path-to-co2-neutrality.html,net_zero_tracker
+net_zero_tracker:529900R5WX9N2OI2N910:2050,529900R5WX9N2OI2N910,Net zero,,2050,,,https://www.sony.com/en/SonyInfo/csr/library/reports/SustainabilityReport2021_E.pdf,net_zero_tracker
+net_zero_tracker:529900S21EQ1BO4ESM68:2050,529900S21EQ1BO4ESM68,Net zero,,2050,,,https://sustainable-performance.totalenergies.com/en/our-challenges/environment-and-climate/climate,net_zero_tracker
+net_zero_tracker:529900S5R9YHJHYKKG94:2050,529900S5R9YHJHYKKG94,Climate neutral,,2050,,,https://www.cez.cz/en/media/press-releases/cez-presents-clean-energy-of-tomorrow-its-production-portfolio-is-to-be-rebuilt-to-low-emissions-by-2030-144329,net_zero_tracker
+net_zero_tracker:529900S7NFNQ4FT6OP83:2050,529900S7NFNQ4FT6OP83,Net zero,,2050,,,https://www.dnp.co.jp/eng/sustainability/,net_zero_tracker
+net_zero_tracker:529900SM0FDLLYATXU36:2030,529900SM0FDLLYATXU36,Climate neutral,,2030,,,https://www.baywa.com/en/responsibility/at-a-glance,net_zero_tracker
+net_zero_tracker:529900TF7XJKIOWMLQ79:2050,529900TF7XJKIOWMLQ79,Net zero,,2050,,,https://www.taisei.co.jp/english/csr/performance/iso26000/environment/,net_zero_tracker
+net_zero_tracker:529900UBKMFM0ST6H474:2050,529900UBKMFM0ST6H474,Climate neutral,,2050,,,https://www.fujifilm.com/files-holdings/en/sustainability/report/2021/sustainabilityreport2021_svpstories_en.pdf,net_zero_tracker
+net_zero_tracker:529900X0H1IO3RS1A464:2050,529900X0H1IO3RS1A464,Net zero,,2050,,,https://www.prudentialplc.com/en/news-and-insights/all-news/news-releases/2021/07-05-2021,net_zero_tracker
+net_zero_tracker:529900YRFFGH5AXU4S86:2019,529900YRFFGH5AXU4S86,Net zero,,2019,,,https://corporate.zalando.com/en/sustainability/reducing-our-carbon-footprint,net_zero_tracker
+net_zero_tracker:54930002KP75TLLLNO21:2040,54930002KP75TLLLNO21,Net zero,,2040,,,https://www.acciona.com/es/nuestro-proposito/sostenibilidad/emergencia-climatica/?_adin=0183579827,net_zero_tracker
+net_zero_tracker:5493000BD5GJNUDIUG10:2020,5493000BD5GJNUDIUG10,Climate neutral,,2020,,,https://www.responsibilityreports.com/HostedData/ResponsibilityReportArchive/m/NYSE_MTD_2019.pdf,net_zero_tracker
+net_zero_tracker:5493000KUC3Z24U77V93:2022,5493000KUC3Z24U77V93,Net zero,,2022,,,https://reporting.swisslife.com/download/2021AR/en/FY21_SustainabilityReport_EN.pdf,net_zero_tracker
+net_zero_tracker:54930012H97VSM0I2R19:2025,54930012H97VSM0I2R19,Climate neutral,,2025,,,https://www.aglmediagroup.com/cci-sets-carbon-neutral-goal/,net_zero_tracker
+net_zero_tracker:5493001EZOOA66PTBR68:2028,5493001EZOOA66PTBR68,Net zero,,2028,,,https://atos.net/en/lp/integrated-report-2019/our-environment,net_zero_tracker
+net_zero_tracker:5493001Z3ZE83NGK8Y12:2050,5493001Z3ZE83NGK8Y12,Net zero,,2050,,,https://www.prudentialplc.com/en/news-and-insights/all-news/news-releases/2021/07-05-2021,net_zero_tracker
+net_zero_tracker:5493002CONDB4N2HKI23:2040,5493002CONDB4N2HKI23,Climate neutral,,2040,,,https://www.parker.com/parkerimages/Parker.com/Countries-2011/United%20States/About%20Us/Documents/Parker%20Sustainability%20Report%202020.pdf,net_zero_tracker
+net_zero_tracker:5493002ENHZ6NYET7405:2030,5493002ENHZ6NYET7405,Climate neutral,,2030,,,https://www.experianplc.com/media/4001/experian-annual-report-2020.pdf,net_zero_tracker
+net_zero_tracker:5493002F0SC4JTBU5137:2030,5493002F0SC4JTBU5137,Climate neutral,,2030,,,https://www.stryker.com/content/m/c/2020-comprehensive-annual-report/environmental-sustainability/carbon-neutrality.html,net_zero_tracker
+net_zero_tracker:54930033SBW53OO8T749:2040,54930033SBW53OO8T749,Net zero,,2040,,,https://www.coned.com/en/our-energy-future/our-energy-vision/our-energy-future-commitment,net_zero_tracker
+net_zero_tracker:5493003BZYYYCDIO0R13:2020,5493003BZYYYCDIO0R13,Climate neutral,,2020,,,https://group.softbank/system/files/pdf/sustainability/report/sustainability-report_fy2021_01sp_en.pdf,net_zero_tracker
+net_zero_tracker:5493003HK03UVPUSUP12:2050,5493003HK03UVPUSUP12,Net zero,,2050,,,https://www.firstrand.co.za/media/investors/annual-reporting/FirstRand-TCFD-report-2021.pdf,net_zero_tracker
+net_zero_tracker:5493003L32ZX9557ST85:2050,5493003L32ZX9557ST85,Net zero,,2050,,,https://2020sustainability.wesfarmers.com.au/docs/default-source/sustainability-documents/wesfarmers_2020_climate-related_disclosure.pdf?sfvrsn=3ccd0bbb_10,net_zero_tracker
+net_zero_tracker:5493003S21INSLK2IP73:2050,5493003S21INSLK2IP73,Climate neutral,,2050,,,https://corporate.dow.com/documents/about/066-00338-01-2020-esg-report.pdf,net_zero_tracker
+net_zero_tracker:54930044KVSC06Z79I06:2050,54930044KVSC06Z79I06,Net zero,,2050,,,https://s21.q4cdn.com/507168367/files/doc_financials/2021/ar/Clorox-2021-Integrated-Annual-Report.pdf,net_zero_tracker
+net_zero_tracker:5493004JF0SDFLM8GD76:2050,5493004JF0SDFLM8GD76,Climate neutral,,2050,,,https://www.dupont.com/about/sustainability/acting-on-climate.html.html,net_zero_tracker
+net_zero_tracker:5493004LQ0B4T7QPQV17:2050,5493004LQ0B4T7QPQV17,Net zero,,2050,,,https://sustainability-cms-komatsu-s3.s3-ap-northeast-1.amazonaws.com/en/csr/pdf/KOMATSUCSR2022_en.pdf,net_zero_tracker
+net_zero_tracker:5493004SE33MRLPB1W98:2050,5493004SE33MRLPB1W98,Climate neutral,,2050,,,https://www.sojitz.com/en/csr/environment/carbon_neutrality/,net_zero_tracker
+net_zero_tracker:5493005DJBML6LY3RV36:2050,5493005DJBML6LY3RV36,Net zero,,2050,,,https://www.ageas.com/sites/default/files/file/file/2021%2006%2001%20-%20Ageas%20IR%20Day%202021%20-%20Impact24.pdf,net_zero_tracker
+net_zero_tracker:5493005SL9HHOXS3B739:2025,5493005SL9HHOXS3B739,Net zero,,2025,,,https://www.swisscom.ch/en/about/news/2021/10/28-netto-null-ziel-2025.html#ms-multipageStep-newsletter,net_zero_tracker
+net_zero_tracker:5493005SP87FL5TOS202:2050,5493005SP87FL5TOS202,Climate neutral,,2050,,,https://www.sumitomocorp.com/en/jp/sustainability/environmental-management/climate,net_zero_tracker
+net_zero_tracker:5493005X2GO78EFZ3E94:2040,5493005X2GO78EFZ3E94,Net zero,,2040,,,https://s201.q4cdn.com/858635754/files/doc_downloads/PayPal-2021-Global-Impact-Report.pdf,net_zero_tracker
+net_zero_tracker:5493006AIPA1V92YPP18:2050,5493006AIPA1V92YPP18,Climate neutral,,2050,,,https://www.sdk.co.jp/english/csr/environment/climate.html,net_zero_tracker
+net_zero_tracker:5493006IEVQEFQO40L83:2050,5493006IEVQEFQO40L83,Net zero,,2050,,,https://www.cognizant.com/us/en/documents/carbon-reduction-plan.pdf,net_zero_tracker
+net_zero_tracker:5493006IH2N2WMIBB742:2050,5493006IH2N2WMIBB742,Climate neutral,,2050,,,https://www.valeo.com/fr/valeo-sengage-a-atteindre-la-neutralite-carbone-en-2050-et-aura-deja-fait-45-du-chemin-dici-a-2030/,net_zero_tracker
+net_zero_tracker:5493006MHB84DD0ZWV18:2030,5493006MHB84DD0ZWV18,Net zero,,2030,,,https://www.gstatic.com/gumdrop/sustainability/google-2022-environmental-report.pdf,net_zero_tracker
+net_zero_tracker:5493006QMFDDMYWIAM13:2050,5493006QMFDDMYWIAM13,Net zero,,2050,,,https://www.santander.com/content/dam/santander-com/en/documentos/informe-anual-de-sostenibilidad/2020/ias-2020-climate-finance-2020-21-en.pdf,net_zero_tracker
+net_zero_tracker:5493006W3QUS5LMH6R84:2050,5493006W3QUS5LMH6R84,Climate neutral,,2050,,,https://global.toyota/pages/global_toyota/sustainability/report/sdb/sdb22_en.pdf,net_zero_tracker
+net_zero_tracker:5493006ZCRFWKF6B1K26:2030,5493006ZCRFWKF6B1K26,Net zero,,2030,,,https://corporate.discovery.com/environmental-social-governance/our-planet/#ghg,net_zero_tracker
+net_zero_tracker:54930070J9H97ZO93T57:2040,54930070J9H97ZO93T57,Net zero,,2040,,,https://www.jetblue.com/sustainability/climate-leadership,net_zero_tracker
+net_zero_tracker:54930070NSV60J38I987:2040,54930070NSV60J38I987,Climate neutral,,2040,,,https://www.gmsustainability.com/_pdf/resources-and-downloads/GM_2020_SR.pdf,net_zero_tracker
+net_zero_tracker:549300772D1G8JPIUR96:2050,549300772D1G8JPIUR96,Net zero,,2050,,,https://www.aegon.com/investors/press-releases/2021/aegon-commits-to-group-wide-net-zero-emissions-objective-by-2050/,net_zero_tracker
+net_zero_tracker:5493007HIVTX6SY6XD66:2040,5493007HIVTX6SY6XD66,Net zero,,2040,,,https://www.novartis.com/our-company/corporate-responsibility/environmental-sustainability/climate,net_zero_tracker
+net_zero_tracker:5493008H3828EMEXB082:2040,5493008H3828EMEXB082,Net zero,,2040,,,https://www.ab-inbev.com/assets/pdfs/Net%20Zero%20Executive%20Summary_FINAL%2012pm.pdf,net_zero_tracker
+net_zero_tracker:5493008IRKIY0G3TE305:2050,5493008IRKIY0G3TE305,Net zero,,2050,,,https://www.anahd.co.jp/group/en/pr/202104/20210426.html,net_zero_tracker
+net_zero_tracker:5493008IUOJ5VWTRC333:2040,5493008IUOJ5VWTRC333,Net zero,,2040,,,https://www.interpublic.com/wp-content/uploads/2021/08/CDP-Climate-Change-Questionnaire-2021_Interpublic-Group.pdf,net_zero_tracker
+net_zero_tracker:5493008T4YG3AQUI7P67:2050,5493008T4YG3AQUI7P67,Net zero,,2050,,,https://www.cellnextelecom.com/content/uploads/2021/07/Cellnex-Telecom_-Environmental-and-Climate-Change-Report.pdf,net_zero_tracker
+net_zero_tracker:5493009ML300G373MZ12:2050,5493009ML300G373MZ12,Net zero,,2050,,,https://www.alliantenergy.com/AboutAlliantEnergy/ResponsibilityReport/CleanEnergyVisionGoals,net_zero_tracker
+net_zero_tracker:549300B2FTG34FILDR98:2040,549300B2FTG34FILDR98,Net zero,,2040,,,https://d1nyezh1ys8wfo.cloudfront.net/static/PDFs/CAsPR_Commitments.pdf?uclick_id=6efc8817-eb1f-4082-9215-eae139f696d8,net_zero_tracker
+net_zero_tracker:549300B6HWYEE57O8J84:2030,549300B6HWYEE57O8J84,Climate neutral,,2030,,,https://www.skf.com/uk/organisation/sustainability/decarbonizing,net_zero_tracker
+net_zero_tracker:549300B8P6MUJ1YWTS08:2040,549300B8P6MUJ1YWTS08,Climate neutral,,2040,,,https://newclimate.org/wp-content/uploads/2022/02/CorporateClimateResponsibilityMonitor2022.pdf,net_zero_tracker
+net_zero_tracker:549300BMOJ05INE4YK86:2030,549300BMOJ05INE4YK86,Net zero,,2030,,,https://esg.vno.com/,net_zero_tracker
+net_zero_tracker:549300BUDHS3LRWBE814:2030,549300BUDHS3LRWBE814,Net zero,,2030,,,https://www.vmware.com/content/dam/digitalmarketing/vmware/en/pdf/company/vmware-esg-report-2021.pdf,net_zero_tracker
+net_zero_tracker:549300BX44RGX6ANDV88:2040,549300BX44RGX6ANDV88,Net zero,,2040,,,https://press.hp.com/us/en/press-releases/2021/hp-inc-announces-ambitious-climate-action-goals.html,net_zero_tracker
+net_zero_tracker:549300BX44RGX6ANDV88:2050,549300BX44RGX6ANDV88,Net zero,,2050,,,https://www.hpe.com/us/en/living-progress/carbon-footprint.html,net_zero_tracker
+net_zero_tracker:549300CEE2ENIUJNXB84:2050,549300CEE2ENIUJNXB84,Climate neutral,,2050,,,https://www.toyota-tsusho.com/english/ir/library/integrated-report/pdf/ar2021e_all.pdf,net_zero_tracker
+net_zero_tracker:549300CZ8QS1GE53O776:2040,549300CZ8QS1GE53O776,Net zero,,2040,,,https://www.jacobs.com/sites/default/files/2022-04/Jacobs%20Climate%20Action%20Plan.pdf,net_zero_tracker
+net_zero_tracker:549300DF5MV96DRYLQ48:2050,549300DF5MV96DRYLQ48,Net zero,,2050,,,https://www.xylem.com/en-uk/making-waves/water-utilities-news/water-utilities-moving-fast-toward-a-zero-carbon-future-white-paper/,net_zero_tracker
+net_zero_tracker:549300DFVPOB67JL3A42:2040,549300DFVPOB67JL3A42,Net zero,,2040,,,https://www.imperialbrandsplc.com/content/dam/imperialbrands/corporate2022/documents/investors/reports/annual-report-2021.pdf.downloadasset.pdf,net_zero_tracker
+net_zero_tracker:549300DHPOF90OYYD780:2050,549300DHPOF90OYYD780,Climate neutral,,2050,,,https://www.bridgestone.com/responsibilities/library/pdf/sr2020.pdf,net_zero_tracker
+net_zero_tracker:549300DRQQI75D2JP341:2050,549300DRQQI75D2JP341,Net zero,,2050,,,https://filecache.investorroom.com/mr5ir_truist/611/Truist%202021%20ESG%20and%20CSR%20Report%20%28ADA%29.pdf,net_zero_tracker
+net_zero_tracker:549300DSFX2IE88NSX47:2035,549300DSFX2IE88NSX47,Net zero,,2035,,,https://www.borgwarner.com/company/sustainability#environmental-stewardship,net_zero_tracker
+net_zero_tracker:549300DV9GIB88LZ5P30:2050,549300DV9GIB88LZ5P30,Net zero,,2050,,,https://www.mondelezinternational.com/-/media/Mondelez/Snacking-Made-Right/SMR-Report/2021/2021-MDLZ-Snacking-Made-Right-ESG-Report.pdf,net_zero_tracker
+net_zero_tracker:549300E3VEW8SMS5XW09:2030,549300E3VEW8SMS5XW09,Climate neutral,,2030,,,https://www.businesswire.com/news/home/20210505006248/en/Olympus-Targets-Carbon-Neutrality-by-2030,net_zero_tracker
+net_zero_tracker:549300E707U7WNPZN687:2040,549300E707U7WNPZN687,Climate neutral,,2040,,,https://www.fedex.com/content/dam/fedex/us-united-states/sustainability/gcrs/FedEx_2021_ESG_Report.pdf,net_zero_tracker
+net_zero_tracker:549300E9PC51EN656011:2050,549300E9PC51EN656011,Climate neutral,,2050,,,https://integrated-report.sanofi.com/strategy/building-sustainability-for-a-healthy-planet/,net_zero_tracker
+net_zero_tracker:549300EEJH4FEPDBBR25:2040,549300EEJH4FEPDBBR25,Net zero,,2040,,,https://www.telefonica.com/documents/364672/413993/telefonica-cdp-climate-change-questionnaire-2020.pdf/4fa2d4f0-3bbd-d391-9931-8671bdb18f65,net_zero_tracker
+net_zero_tracker:549300EFP3TNG7JGVE49:2040,549300EFP3TNG7JGVE49,Net zero,,2040,,,https://www.coca-colahellenic.com/en/media/news/sustainability_news/2021/coca-cola-hbc-commits-to-net-zero-emissions-by-2040,net_zero_tracker
+net_zero_tracker:549300EI6OKH5K5Q2G38:2040,549300EI6OKH5K5Q2G38,Net zero,,2040,,,https://www.mtn.com/mtn-commits-to-net-zero-emissions-by-2040-to-contribute-to-a-sustainable-future/,net_zero_tracker
+net_zero_tracker:549300EJG376EN5NQE29:2050,549300EJG376EN5NQE29,Net zero,,2050,,,https://cvshealth.com/sites/default/files/2020-csr-report.pdf,net_zero_tracker
+net_zero_tracker:549300EJG9IEYQL5XT21:2050,549300EJG9IEYQL5XT21,Net zero,,2050,,,https://www.tiffany.co.uk/sustainability/the-planet/efficient-energy/,net_zero_tracker
+net_zero_tracker:549300EVUN2BTLJ3GT74:2030,549300EVUN2BTLJ3GT74,Climate neutral,,2030,,,https://www.equinix.co.uk/newsroom/press-releases/2021/06/equinix-sets-2030-global-climate-neutral-target,net_zero_tracker
+net_zero_tracker:549300FA4CTCW903Y781:2050,549300FA4CTCW903Y781,Climate neutral,,2050,,,https://www.caesars.com/corporate/corporate-social-responsibility/planet/climate,net_zero_tracker
+net_zero_tracker:549300FC3G3YU2FBZD92:2050,549300FC3G3YU2FBZD92,Net zero,,2050,,,https://www.southerncompany.com/sustainability/net-zero-and-environmental-priorities/net-zero-transition.html,net_zero_tracker
+net_zero_tracker:549300FEKNPCFSA2B506:2050,549300FEKNPCFSA2B506,Climate neutral,,2050,,,https://www.osakagas.co.jp/csr_e/beginning/carbon_neutral_vision.html,net_zero_tracker
+net_zero_tracker:549300FONLMVK7YYYH41:2050,549300FONLMVK7YYYH41,Net zero,,2050,,,https://www.suntory.com/csr/activity/environment/management/vision/,net_zero_tracker
+net_zero_tracker:549300G0CFPGEF6X2043:2045,549300G0CFPGEF6X2043,Net zero,,2045,,,https://www.jnj.com/environmental-sustainability/climate-and-energy-action,net_zero_tracker
+net_zero_tracker:549300GCEDD8YCF5WU84:2040,549300GCEDD8YCF5WU84,Net zero,,2040,,,https://www.moodys.com/sites/products/ProductAttachments/Sustainability/moodys_decarbonization_plan.pdf,net_zero_tracker
+net_zero_tracker:549300GHBMY8T5GXDE41:2035,549300GHBMY8T5GXDE41,Net zero,,2035,,,https://www.unitedhealthgroup.com/content/dam/UHG/PDF/About/UNH-enivronmental-impact-statement.pdf,net_zero_tracker
+net_zero_tracker:549300GLKVIO8YRCYN02:2040,549300GLKVIO8YRCYN02,Net zero,,2040,,,https://www.keysight.com/us/en/assets/7018-06607/brochures/5992-3927.pdf,net_zero_tracker
+net_zero_tracker:549300HGGKEL4FYTTQ83:2050,549300HGGKEL4FYTTQ83,Climate neutral,,2050,,,http://sustainability.steeldynamics.com/valuing-our-environment/,net_zero_tracker
+net_zero_tracker:549300HGV012CNC8JD22:2050,549300HGV012CNC8JD22,Net zero,,2050,,,https://www.volvogroup.com/en/sustainability/climate-goals-strategy/reducing-carbon-emissions.html,net_zero_tracker
+net_zero_tracker:549300HJTQM36M0E1G39:2050,549300HJTQM36M0E1G39,Net zero,,2050,,,https://www.servicenow.com/content/dam/servicenow-assets/public/en-us/doc-type/other-document/servicenow-global-impact-report-2021.pdf,net_zero_tracker
+net_zero_tracker:549300HOF34RGOJ5YL07:2020,549300HOF34RGOJ5YL07,Climate neutral,,2020,,,https://jefferies.com/CMSFiles/Jefferies.com/files/Sustainability/JEF-2021-ESG-Report.pdf,net_zero_tracker
+net_zero_tracker:549300HTIN2PD78UB763:2040,549300HTIN2PD78UB763,Net zero,,2040,,,https://www.msci.com/who-we-are/corporate-responsibility/operate-sustainably,net_zero_tracker
+net_zero_tracker:549300I4GMO6D34U1T02:2050,549300I4GMO6D34U1T02,Net zero,,2050,,,https://www.lamresearch.com/esg-report/downloads/Lam-Research-2021-ESG-Report.pdf,net_zero_tracker
+net_zero_tracker:549300I7ROF15MAEVP56:2045,549300I7ROF15MAEVP56,Net zero,,2045,,,https://www.edison.com/content/dam/eix/documents/sustainability/eix-2021-sustainability-report.pdf,net_zero_tracker
+net_zero_tracker:549300IA9XFBAGNIBW29:2040,549300IA9XFBAGNIBW29,Net zero,,2040,,,https://www.consumersenergy.com/-/media/CE/Documents/company/IRP-2021.ashx,net_zero_tracker
+net_zero_tracker:549300IGLYTZUK3PVP70:2050,549300IGLYTZUK3PVP70,Net zero,,2050,,,https://www.wecenergygroup.com/home/generation-reshaping-plan.htm,net_zero_tracker
+net_zero_tracker:549300IRDTHJQ1PVET45:2050,549300IRDTHJQ1PVET45,Net zero,,2050,,,https://www.responsibilityreports.com/HostedData/ResponsibilityReports/PDF/NYSE_FCX_2020.pdf,net_zero_tracker
+net_zero_tracker:549300ITS31QK8VRBQ14:2050,549300ITS31QK8VRBQ14,Net zero,,2050,,,https://newscorp.com/news-corp-sustainability/,net_zero_tracker
+net_zero_tracker:549300IULC8F8IGXKI15:2030,549300IULC8F8IGXKI15,Climate neutral,,2030,,,https://www.lundin-energy.com/sustainability/climate-change/decarbonisation-strategy/,net_zero_tracker
+net_zero_tracker:549300IX8SD6XXD71I78:2050,549300IX8SD6XXD71I78,Net zero,,2050,,,https://dtecleanenergy.com/,net_zero_tracker
+net_zero_tracker:549300J0DYC0N31V7G13:2021,549300J0DYC0N31V7G13,Net zero,,2021,,,https://www.workday.com/en-gb/company/corporate-responsibility/sustainability.html,net_zero_tracker
+net_zero_tracker:549300J4U55H3WP1XT59:2050,549300J4U55H3WP1XT59,Net zero,,2050,,,https://www.bayer.com/en/sustainability/climate-protection,net_zero_tracker
+net_zero_tracker:549300JBN1OSM8YNAI90:2022,549300JBN1OSM8YNAI90,Climate neutral,,2022,,,https://www.ally.com/files/pdf/ally-corporate-social-responsibility-report-2021.pdf,net_zero_tracker
+net_zero_tracker:549300JE8XHZZ7OHN517:2050,549300JE8XHZZ7OHN517,Net zero,,2050,,,https://www.yum.com/wps/portal/yumbrands/Yumbrands/citizenship-and-sustainability/planet,net_zero_tracker
+net_zero_tracker:549300JF6LPRTRJ0FH50:2050,549300JF6LPRTRJ0FH50,Net zero,,2050,,,https://corporate.kohls.com/content/dam/kohlscorp/corporate-responsibility/landing-page/Kohls-ESG%20Report.pdf,net_zero_tracker
+net_zero_tracker:549300JQQA6MQ4OJP259:2050,549300JQQA6MQ4OJP259,Net zero,,2050,,,https://mccormick.widen.net/s/x5bmvpfgc7/2021_plp_report,net_zero_tracker
+net_zero_tracker:549300JSX0Z4CW0V5023:2050,549300JSX0Z4CW0V5023,Climate neutral,,2050,,,https://www.adidas-group.com/media/filer_public/a8/5c/a85c9b8e-865b-4237-8def-8574be243577/annual_report_gb-2019_en.pdf,net_zero_tracker
+net_zero_tracker:549300JZ4OKEHW3DPJ59:2040,549300JZ4OKEHW3DPJ59,Net zero,,2040,,,https://usa.visa.com/visa-everywhere/blog/bdp/2021/04/15/sustainable-commerce-and-1618453815474.html,net_zero_tracker
+net_zero_tracker:549300KI75VYLLMSK856:2050,549300KI75VYLLMSK856,Net zero,,2050,,,https://www.sse.com/media/q0ilyek3/net-zero-transition-report-final.pdf,net_zero_tracker
+net_zero_tracker:549300KMHPUAQI8VEH90:2050,549300KMHPUAQI8VEH90,Climate neutral,,2050,,,https://www.jpower.co.jp/english/ir/ir51000.html,net_zero_tracker
+net_zero_tracker:549300KP43CPCUJOOG15:2050,549300KP43CPCUJOOG15,Net zero,,2050,,,https://www.vistracorp.com/wp-content/uploads/2020/11/VST-2020-Climate-Report.pdf,net_zero_tracker
+net_zero_tracker:549300LBHTST91VKHO68:2050,549300LBHTST91VKHO68,Net zero,,2050,,,https://www.toshiba.co.jp/env/en/vision/vision2050_0.htm,net_zero_tracker
+net_zero_tracker:549300LKFJ962MZ46593:2040,549300LKFJ962MZ46593,Net zero,,2040,,,https://www.cisco.com/c/dam/m/en_us/about/csr/esg-hub/_pdf/purpose-report-2021.pdf,net_zero_tracker
+net_zero_tracker:549300LMMRSZZCZ8CL11:2050,549300LMMRSZZCZ8CL11,Net zero,,2050,,,https://www.responsibilityreports.com/HostedData/ResponsibilityReports/PDF/NYSE_UNP_2021.pdf,net_zero_tracker
+net_zero_tracker:549300LRIF3NWCU26A80:2050,549300LRIF3NWCU26A80,Net zero,,2050,,,https://www.blackrock.com/corporate/investor-relations/blackrock-client-letter,net_zero_tracker
+net_zero_tracker:549300LSGBXPYHXGDT93:2030,549300LSGBXPYHXGDT93,Net zero,,2030,,,https://www.wpp.com/-/media/project/wpp/files/sustainability/reports/2021/wpp_sr_2021_interactive-------.pdf?la=en,net_zero_tracker
+net_zero_tracker:549300LTH67W4GWMRF57:2040,549300LTH67W4GWMRF57,Net zero,,2040,,,https://www.cocacolaep.com/assets/2021-CCEP-Integrated-Report-and-Form-20-F_v2-v2.pdf,net_zero_tracker
+net_zero_tracker:549300LWGYFM1TVO1Z12:2050,549300LWGYFM1TVO1Z12,Net zero,,2050,,,https://www.newcrest.com/sites/default/files/2021-05/Net%20Zero%20Statement.pdf,net_zero_tracker
+net_zero_tracker:549300M3VH1A3ER1TB49:2050,549300M3VH1A3ER1TB49,Net zero,,2050,,,https://www.essity.com/sustainability/our-journey-to-net-zero/climate-targets/,net_zero_tracker
+net_zero_tracker:549300MKFYEKVRWML317:2039,549300MKFYEKVRWML317,Net zero,,2039,,,https://assets.unilever.com/files/92ui5egz/production/bbe89d14aa9e0121dd3a2b9721bbfd3bef57b8d3.pdf/unilever-climate-transition-action-plan-19032021.pdf,net_zero_tracker
+net_zero_tracker:549300MMVL80RTBP3O28:2050,549300MMVL80RTBP3O28,Climate neutral,,2050,,,https://www.solvay.com/en/sustainability/climate,net_zero_tracker
+net_zero_tracker:549300MR6PG2DWZUIL39:2050,549300MR6PG2DWZUIL39,Net zero,,2050,,,https://www.aramark.com/content/dam/aramark/en/environmental-social-governance/reporting/Aramark-2021-Impact-Report.pdf,net_zero_tracker
+net_zero_tracker:549300N0B7DOGLXWPP39:2050,549300N0B7DOGLXWPP39,Net zero,,2050,,,https://s24.q4cdn.com/367535798/files/doc_downloads/2022/06/FINAL-2021-Aflac-Incorporated-Bus.pdf,net_zero_tracker
+net_zero_tracker:549300N244BVAEE6HH86:2050,549300N244BVAEE6HH86,Climate neutral,,2050,,,https://www.subaru.co.jp/en/csr/subaru_csr/sixpriority/environment.html,net_zero_tracker
+net_zero_tracker:549300NOMHGVQBX6S778:2040,549300NOMHGVQBX6S778,Net zero,,2040,,,https://s21.q4cdn.com/254933054/files/doc_downloads/global_responsibility/Global-Payments_2021_Global_Responsibility_Report.pdf,net_zero_tracker
+net_zero_tracker:549300NUB6D2R1ITYR45:2019,549300NUB6D2R1ITYR45,Climate neutral,,2019,,,https://csr.hasbro.com/en-us/news/article?id=news_article_renewable_energy_2018,net_zero_tracker
+net_zero_tracker:549300NYKK9MWM7GGW15:2050,549300NYKK9MWM7GGW15,Net zero,,2050,,,https://www.ing.com/Sustainability/The-world-around-us-1/Reporting.htm,net_zero_tracker
+net_zero_tracker:549300OF70FSEUQBT254:2025,549300OF70FSEUQBT254,Climate neutral,,2025,,,https://www.bxp.com/commitment,net_zero_tracker
+net_zero_tracker:549300OHIIUWSTIZME52:2030,549300OHIIUWSTIZME52,Net zero,,2030,,,https://squareup.com/us/en/press/carbon,net_zero_tracker
+net_zero_tracker:549300OJ9VZHZRO6I137:2040,549300OJ9VZHZRO6I137,Net zero,,2040,,,https://s23.q4cdn.com/539497486/files/doc_downloads/2022/04/Tractor-Supply-Sustainability-Report-FY2021.pdf,net_zero_tracker
+net_zero_tracker:549300P0R46FF6DUA630:2050,549300P0R46FF6DUA630,Climate neutral,,2050,,,https://sustainability.idemitsu.com/en/themes/311,net_zero_tracker
+net_zero_tracker:549300P7ZYCQJ36CCS16:2050,549300P7ZYCQJ36CCS16,Climate neutral,,2050,,,https://global.honda/content/dam/site/global/about/cq_img/sustainability/report/pdf/2021/Honda-SR-2021-en-all.pdf,net_zero_tracker
+net_zero_tracker:549300PGTHDQY6PSUI61:2045,549300PGTHDQY6PSUI61,Net zero,,2045,,,https://investors.evergy.com/news-releases/news-release-details/evergy-sets-goal-net-zero-carbon-emissions-2045-interim-carbon,net_zero_tracker
+net_zero_tracker:549300PPXHEU2JF0AM85:2030,549300PPXHEU2JF0AM85,Net zero,,2030,,,https://www.lloydsbankinggroup.com/who-we-are/responsible-business/financing-a-green-future/our-sustainability-commitments.html,net_zero_tracker
+net_zero_tracker:549300PW7VPFCYKLIV37:2050,549300PW7VPFCYKLIV37,Net zero,,2050,,,https://esg.averydennison.com/en/home/environmental-footprint/ghg-emissions-and-energy-use.html,net_zero_tracker
+net_zero_tracker:549300QXR2YVZV231H43:2030,549300QXR2YVZV231H43,Climate neutral,,2030,,,https://www.paloaltonetworks.com/blog/2021/02/cc-carbon-neutral-2030/,net_zero_tracker
+net_zero_tracker:549300R22LSX6OHWEN64:2021,549300R22LSX6OHWEN64,Net zero,,2021,,,https://www.diamondbackenergy.com/news-releases/news-release-details/diamondback-energy-inc-announces-fourth-quarter-and-full-year-1,net_zero_tracker
+net_zero_tracker:549300RYPA10CQM3QK38:2035,549300RYPA10CQM3QK38,Climate neutral,,2035,,,https://www.denso.com/-/media/global/about-us/investors/annual-report/2021/annual-report-doc-2021-a3-en-2.pdf?la=en&rev=48ec7520ca7547ad9258ca3edbc46c70&hash=4521F78BE462C39346CAA7AB5513614C,net_zero_tracker
+net_zero_tracker:549300S9XF92D1X8ME43:2040,549300S9XF92D1X8ME43,Climate neutral,,2040,,,https://www.angloamerican.com/~/media/Files/A/Anglo-American-Group/PLC/investors/annual-reporting/2022/aa-sustainability-report-full-2021.pdf,net_zero_tracker
+net_zero_tracker:549300SQYI82RVWFN715:2040,549300SQYI82RVWFN715,Climate neutral,,2040,,,https://responsibility.metroag.de/focus-areas/climate-action,net_zero_tracker
+net_zero_tracker:549300SVYJS666PQJH88:2050,549300SVYJS666PQJH88,Climate neutral,,2050,,,https://www.firstenergycorp.com/newsroom/news_articles/firstenergy-pledges-to-achieve-carbon-neutrality-by-2050.html,net_zero_tracker
+net_zero_tracker:549300T065Z4KJ686G75:2017,549300T065Z4KJ686G75,Climate neutral,,2017,,,https://corporate.voya.com/corporate-responsibility/protecting-environment/operational-eco-efficiency,net_zero_tracker
+net_zero_tracker:549300T6IPOCDWLKC615:2050,549300T6IPOCDWLKC615,Net zero,,2050,,,https://sustainability.hitachi.com/wp-content/uploads/2021/10/en_sustainability2021_full.pdf,net_zero_tracker
+net_zero_tracker:549300TO56L57RP6P031:2021,549300TO56L57RP6P031,Climate neutral,,2021,,,https://www.annualreports.com/HostedData/AnnualReportArchive/i/NASDAQ_IAC_2018.pdf,net_zero_tracker
+net_zero_tracker:549300TPQQDBP9GNOF40:2050,549300TPQQDBP9GNOF40,Net zero,,2050,,,https://ourcommitments.activisionblizzard.com/wp-content/uploads/ATVI-2020-ESG-Report-06.11.21-FINAL.pdf,net_zero_tracker
+net_zero_tracker:549300TRUWO2CD2G5692:2030,549300TRUWO2CD2G5692,Net zero,,2030,,,https://www.unicreditgroup.eu/content/dam/unicreditgroup-eu/documents/en/sustainability/sustainability-reports/2021/UC_INTEGRATO_2021_ENG.pdf,net_zero_tracker
+net_zero_tracker:549300TRXM9Y6561AX39:2050,549300TRXM9Y6561AX39,Net zero,,2050,,,https://www.mitsubishielectric.com/en/sustainability/reports/pdf/2021/Sustainability_report_2021_all.pdf,net_zero_tracker
+net_zero_tracker:549300TTCXZOGZM2EY83:2040,549300TTCXZOGZM2EY83,Net zero,,2040,,,https://www.inditex.com/our-commitment-to-the-environment/climate-change-and-energy,net_zero_tracker
+net_zero_tracker:549300UCKT2UK88AG251:2030,549300UCKT2UK88AG251,Climate neutral,,2030,,,https://www.alfalaval.com/globalassets/documents/about-us/sustainablity/sustainability-reports/alfa_laval_sustainability_report__2020.pdf,net_zero_tracker
+net_zero_tracker:549300UDG16DOYUPR330:2050,549300UDG16DOYUPR330,Climate neutral,,2050,,,https://ucpcdn.thyssenkrupp.com/_binary/UCPthyssenkruppAG/en/investors/presentations-and-events/capital-market-days/berichterstattung-und-publikationen-kopie/link-thyssenkrupp-GB-2019-2020-EN-Web.pdf,net_zero_tracker
+net_zero_tracker:549300UINV5RINHGMG07:2045,549300UINV5RINHGMG07,Net zero,,2045,,,https://group.skanska.com/4938df/siteassets/investors/reports-publications/annual-reports/2021/annual-and-sustainability-report-2021.pdf,net_zero_tracker
+net_zero_tracker:549300UPNBTXA1SYTQ33:2050,549300UPNBTXA1SYTQ33,Net zero,,2050,,,https://assets.website-files.com/6019e43dcfad3c059841794a/60a6d3d36ca419aff05b0371_2020%20Sustainability%20Report%20052021-min.pdf,net_zero_tracker
+net_zero_tracker:549300V62YJ9HTLRI486:2050,549300V62YJ9HTLRI486,Net zero,,2050,,,https://reports.omv.com/en/sustainability-report/2021/servicepages/downloads/files/entire-omv-sr21.pdf,net_zero_tracker
+net_zero_tracker:549300V9QSIG4WX4GJ96:2040,549300V9QSIG4WX4GJ96,Climate neutral,,2040,,,https://newclimate.org/wp-content/uploads/2022/02/CorporateClimateResponsibilityMonitor2022.pdf,net_zero_tracker
+net_zero_tracker:549300VGEJKB7SVUZR78:2050,549300VGEJKB7SVUZR78,Net zero,,2050,,,https://keringcorporate.dam.kering.com/m/3832efa4c93e4a96/original/KERING_ClimateStrategy2021.pdf,net_zero_tracker
+net_zero_tracker:549300VIWYMSIGT1U456:2040,549300VIWYMSIGT1U456,Climate neutral,,2040,,,https://www.cigna.com/about-us/corporate-responsibility/report/environment/sustainability-performance-plan,net_zero_tracker
+net_zero_tracker:549300VSP3RIX7FGDZ51:2050,549300VSP3RIX7FGDZ51,Net zero,,2050,,,https://s24.q4cdn.com/382246808/files/doc_downloads/sustainability/2021-report/newmont-2021-sustainability-report.pdf,net_zero_tracker
+net_zero_tracker:549300W384M3RI3VXU42:2040,549300W384M3RI3VXU42,Net zero,,2040,,,https://www.gruppotim.it/content/dam/gt/sostenibilit%C3%A0/doc-bilanci/Sustainability-Report-2021.pdf,net_zero_tracker
+net_zero_tracker:549300WR7IX8XE0TBO16:2050,549300WR7IX8XE0TBO16,Net zero,,2050,,,https://www.ingaa.org/News/PressReleases/38525.aspx,net_zero_tracker
+net_zero_tracker:549300WSX3VBUFFJOO66:2040,549300WSX3VBUFFJOO66,Net zero,,2040,,,https://www.relx.com/media/press-releases/year-2021/net-zero,net_zero_tracker
+net_zero_tracker:549300WTZWR07K8MNV44:2030,549300WTZWR07K8MNV44,Net zero,,2030,,,https://www.gilead.com/-/media/files/pdfs/yir-2021-pdfs/2021-gilead-yir_desktop.pdf?la=en&hash=5435F68EB8113745A8756DB75947E7B4,net_zero_tracker
+net_zero_tracker:549300X383CBNP6MTV94:2050,549300X383CBNP6MTV94,Net zero,,2050,,,https://investors.footlocker-inc.com/static-files/8293fa73-de5e-4e36-a8be-c5bf476f2bcd,net_zero_tracker
+net_zero_tracker:549300X3UK4GG3FNMO06:2050,549300X3UK4GG3FNMO06,Net zero,,2050,,,https://www.edf.fr/en/the-edf-group/taking-action-as-a-responsible-company/reports-and-indicators/2021-impact-report,net_zero_tracker
+net_zero_tracker:549300XMP3KDCKJXIU47:2050,549300XMP3KDCKJXIU47,Net zero,,2050,,,https://www.marshmclennan.com/content/dam/mmc-web/v3/esg/Marsh-McLennan-2021-ESG-Report-FINAL.pdf,net_zero_tracker
+net_zero_tracker:549300XU3XH6F05YEQ93:2050,549300XU3XH6F05YEQ93,Net zero,,2050,,,https://www.bakerhughes.com/company/corporate-responsibility/planet/energy-and-climate,net_zero_tracker
+net_zero_tracker:549300Y650407RU8B149:2030,549300Y650407RU8B149,Climate neutral,,2030,,,https://sustainability.travelers.com/iw-documents/sustainability/Travelers_SustainabilityReport2021.pdf,net_zero_tracker
+net_zero_tracker:549300Y7FWSTSHMW5Y57:2050,549300Y7FWSTSHMW5Y57,Net zero,,2050,,,https://www.daikin.com/-/media/Project/Daikin/daikin_com/csr/report/2021/daikin_csr2021_Eng_all-pdf.pdf?rev=-1&hash=F0B8EE23298A9C50AC0FA3B6BA170C9C,net_zero_tracker
+net_zero_tracker:549300Y7VHGU0I7CE873:2022,549300Y7VHGU0I7CE873,Net zero,,2022,,,https://s22.q4cdn.com/959853165/files/doc_downloads/2022/03/30/2021-SASB-Report-FINAL.pdf,net_zero_tracker
+net_zero_tracker:549300YECS8HKCIMMB67:2050,549300YECS8HKCIMMB67,Net zero,,2050,,,https://www.assaabloy.com/group/en/news-media/press-releases/id.CFA9811B900E9B83,net_zero_tracker
+net_zero_tracker:549300YKTY8JX1DV2R67:2050,549300YKTY8JX1DV2R67,Net zero,,2050,,,https://investor.ncr.com/node/31491/pdf,net_zero_tracker
+net_zero_tracker:549300Z40J86GGSTL398:2035,549300Z40J86GGSTL398,Climate neutral,,2035,,,https://about.att.com/csr/home/reporting/issue-brief/climate-change.html,net_zero_tracker
+net_zero_tracker:549300ZFEEJ2IP5VME73:2050,549300ZFEEJ2IP5VME73,Net zero,,2050,,,https://www.statestreet.com/content/dam/statestreet/documents/values/state-street-esg-report-04-2021.pdf,net_zero_tracker
+net_zero_tracker:549300ZLMVP4X0OGR454:2040,549300ZLMVP4X0OGR454,Net zero,,2040,,,https://www.takeda.com/49f45f/siteassets/system/corporate-responsibility/reporting-on-sustainability/tcfd.pdf,net_zero_tracker
+net_zero_tracker:5E2UPK5SW04M13XY7I38:2050,5E2UPK5SW04M13XY7I38,Net zero,,2050,,,https://www.nrg.com/assets/documents/sustainability/2021-sustainability-report.pdf,net_zero_tracker
+net_zero_tracker:5QK37QC7NWOJ8D7WVQ45:2050,5QK37QC7NWOJ8D7WVQ45,Climate neutral,,2050,,,https://www.iberdrola.com/sustainability/committed-sustainable-development-goals/sdg-13-climate-action,net_zero_tracker
+net_zero_tracker:62QBXGPJ34PQ72Z12S66:2027,62QBXGPJ34PQ72Z12S66,Climate neutral,,2027,,,https://www.amgen.com/responsibility/environmental-sustainability/2027-plan,net_zero_tracker
+net_zero_tracker:6SHGI4ZSSLCXXQSBB395:2050,6SHGI4ZSSLCXXQSBB395,Net zero,,2050,,,https://www.responsibilityreports.com/HostedData/ResponsibilityReports/PDF/NYSE_C_2021.pdf,net_zero_tracker
+net_zero_tracker:6SYKCME112RT8TQUO411:2040,6SYKCME112RT8TQUO411,Net zero,,2040,,,https://www.jll.co.uk/content/dam/jll-com/documents/pdf/other/jll-global-sustainability-full-report-2020.pdf,net_zero_tracker
+net_zero_tracker:724500973ODKK3IFQ447:2019,724500973ODKK3IFQ447,Net zero,,2019,,,https://www.adyen.com/social-responsibility/climate#neutral,net_zero_tracker
+net_zero_tracker:724500K5PTPSST86UQ23:2040,724500K5PTPSST86UQ23,Net zero,,2040,,,https://www.theheinekencompany.com/sites/theheinekencompany/files/Downloads/PDF/sustainability%20and%20responsibility/heineken-on-the-path-to-net-zero-2021.pdf?_ga=2.145104438.301010175.1647426557-347249191.1647426557,net_zero_tracker
+net_zero_tracker:724500OHYNDT9OY6Q215:2050,724500OHYNDT9OY6Q215,Net zero,,2050,,,https://www.nn-group.com/nn-group/file?uuid=fe0ed772-850a-4697-95e5-06a1fe376e0f&owner=84c25534-c28a-4a64-9c78-5cc1388e4766&contentid=11805,net_zero_tracker
+net_zero_tracker:724500SNT1MK246AHP04:2050,724500SNT1MK246AHP04,Net zero,,2050,,,https://www.dsm.com/corporate/sustainability/climate-energy/improving-our-carbon-footprint.html,net_zero_tracker
+net_zero_tracker:724500XYIJUGXAA5QD70:2050,724500XYIJUGXAA5QD70,Climate neutral,,2050,,,https://www.akzonobel.com/en/about-us/position-statements/climate-change,net_zero_tracker
+net_zero_tracker:724500Y6DUVHQD6OXN27:2040,724500Y6DUVHQD6OXN27,Net zero,,2040,,,https://www.asml.com/en/investors/annual-report,net_zero_tracker
+net_zero_tracker:765LHXWGK1KXCLTFYQ30:2040,765LHXWGK1KXCLTFYQ30,Climate neutral,,2040,,,https://www.pfizer.com/news/articles/net_zero_by_2040_how_pfizer_is_fighting_climate_change_with_ambitious_science_based_goals,net_zero_tracker
+net_zero_tracker:784F5XWPLTWKTBV3E584:2050,784F5XWPLTWKTBV3E584,Net zero,,2050,,,https://www.goldmansachs.com/our-commitments/sustainability/sustainable-finance/our-operational-impact/2025-operational-commitments/index.html,net_zero_tracker
+net_zero_tracker:7890005U0H950VH19H45:2050,7890005U0H950VH19H45,Climate neutral,,2050,,,https://www.kobelco.co.jp/english/about_kobelco/outline/integrated-reports/files/integrated-reports2021_e.pdf,net_zero_tracker
+net_zero_tracker:789000TUMN63Z28TJ497:2025,789000TUMN63Z28TJ497,Climate neutral,,2025,,,https://www.akbankinvestorrelations.com/en/images/pdf/Akbank-Sustainable-Finance-Framework.pdf,net_zero_tracker
+net_zero_tracker:7CUNS533WID6K7DGFI87:2050,7CUNS533WID6K7DGFI87,Net zero,,2050,,,https://www.caixabank.com/deployedfiles/caixabank_com/Estaticos/PDFs/Accionistasinversores/Informacion_economico_financiera/IGC_30062022_ING.pdf,net_zero_tracker
+net_zero_tracker:7LTWFZYICNSX8D621K86:2050,7LTWFZYICNSX8D621K86,Net zero,,2050,,,https://investor-relations.db.com/files/documents/annual-reports/2022/Non-Financial_Report_2021.pdf?language_id=1,net_zero_tracker
+net_zero_tracker:815600354DEDBD0BA991:2030,815600354DEDBD0BA991,Climate neutral,,2030,,,https://www.annualreports.com/HostedData/AnnualReports/PDF/poste-italiane_2021.pdf,net_zero_tracker
+net_zero_tracker:82DYEISM090VG8LTLS26:2050,82DYEISM090VG8LTLS26,Net zero,,2050,,,https://en-uk.ecolab.com/corporate-responsibility/2030-impact-goals,net_zero_tracker
+net_zero_tracker:851WYGNLUQLFZBSYGB56:2050,851WYGNLUQLFZBSYGB56,Net zero,,2050,,,https://www.commerzbank.de/en/nachhaltigkeit/gesellschaft/klimastrategie/standardseitenvorlage_3.html,net_zero_tracker
+net_zero_tracker:8I5DZWZKVSZI1NUHU748:2020,8I5DZWZKVSZI1NUHU748,Climate neutral,,2020,,,https://www.jpmorganchase.com/content/dam/jpmc/jpmorgan-chase-and-co/documents/jpmc-esg-report-2020.pdf,net_zero_tracker
+net_zero_tracker:8R95QZMKZLJX5Q2XR704:2050,8R95QZMKZLJX5Q2XR704,Net zero,,2050,,,https://www.nationalgrid.com/stories/journey-to-net-zero/national-grids-net-zero-commitment,net_zero_tracker
+net_zero_tracker:8SVCSVKSGDWMW2QHOH83:2050,8SVCSVKSGDWMW2QHOH83,Net zero,,2050,,,https://www.baesystems.com/en/blog/our-commitment-to-net-zero,net_zero_tracker
+net_zero_tracker:8WDDFXB5T1Z6J0XC1L66:2040,8WDDFXB5T1Z6J0XC1L66,Net zero,,2040,,,https://corporate.target.com/corporate-responsibility/planet/climate,net_zero_tracker
+net_zero_tracker:8YQ2GSDWYZXO2EDN3511:2045,8YQ2GSDWYZXO2EDN3511,Climate neutral,,2045,,,https://www.pgecorp.com/corp_responsibility/reports/2019/assets/PGE_CRSR_2019.pdf,net_zero_tracker
+net_zero_tracker:95980020140005007414:2050,95980020140005007414,Climate neutral,,2050,,,https://www.inmocolonial.com/sites/default/files/69792_colonial_2020_web_eng.pdf,net_zero_tracker
+net_zero_tracker:95980020140005693107:2030,95980020140005693107,Climate neutral,,2030,,,https://www.mapfre.com/en/climate-change/,net_zero_tracker
+net_zero_tracker:95980020140005757903:2050,95980020140005757903,Climate neutral,,2050,,,https://www.ferrovial.com/wp-content/uploads/2021/05/climate-strategy-2020-ferrovial.pdf,net_zero_tracker
+net_zero_tracker:9598004A3FTY3TEHHN09:2050,9598004A3FTY3TEHHN09,Net zero,,2050,,,https://corporate.amadeus.com/documents/en/resources/corporate-information/corporate-documents/global-reports/2020/amadeus-global-report-2020.pdf,net_zero_tracker
+net_zero_tracker:959800HSSNXWRKBK4N60:2050,959800HSSNXWRKBK4N60,Net zero,,2050,,,https://www.grifols.com/documents/3625622/3683813/sustainability-report-2021-en.pdf/9588cf72-d301-5beb-da48-ff3469851746?t=1647279808393,net_zero_tracker
+net_zero_tracker:959800R7QMXKF0NFMT29:2040,959800R7QMXKF0NFMT29,Net zero,,2040,,,https://portal.aena.es/en/corporate/climate-change.html,net_zero_tracker
+net_zero_tracker:96950032TUYMW11FB530:2050,96950032TUYMW11FB530,Net zero,,2050,,,https://www.alstom.com/sites/alstom.com/files/2021/07/07/20210706_Alstom_Universal_Registration_Document__EN.pdf,net_zero_tracker
+net_zero_tracker:9695003E4MMA10IBTR26:2050,9695003E4MMA10IBTR26,Net zero,,2050,,,https://www.gecina.fr/sites/default/files/2019-04/rapportclimat_gb_240716_1225.pdf,net_zero_tracker
+net_zero_tracker:96950077L0TN7BAROX36:2030,96950077L0TN7BAROX36,Net zero,,2030,,,https://www.capgemini.com/our-company/our-corporate-social-responsibility-program/environmental-sustainability/,net_zero_tracker
+net_zero_tracker:969500A1YF1XUYYXS284:2050,969500A1YF1XUYYXS284,Net zero,,2050,,,https://www.se.com/ww/en/assets/564/document/322964/sustainability-report-2021.pdf,net_zero_tracker
+net_zero_tracker:969500AQW31GYO8JZD66:2050,969500AQW31GYO8JZD66,Net zero,,2050,,,https://corporate.airfrance.com/en/news/air-france-launches-its-air-france-act-programme-presenting-its-new-co2-emissions-reduction,net_zero_tracker
+net_zero_tracker:969500F7JLTX36OUI695:2040,969500F7JLTX36OUI695,Climate neutral,,2040,,,https://www.renaultgroup.com/wp-content/uploads/2021/04/220421_climate-report-renault-group_8mb.pdf,net_zero_tracker
+net_zero_tracker:969500FZ9BTRZS3JNB97:2035,969500FZ9BTRZS3JNB97,Net zero,,2035,,,https://www.iliad.fr/en/actualites/article/climate-strategy-major-headway-in-7-areas-168,net_zero_tracker
+net_zero_tracker:969500KMUQ2B6CBAF162:2050,969500KMUQ2B6CBAF162,Net zero,,2050,,,https://www.danone.com/impact/planet/towards-carbon-neutrality.html,net_zero_tracker
+net_zero_tracker:969500LCBOG12HXPYM84:2050,969500LCBOG12HXPYM84,Net zero,,2050,,,https://www.sodexo.com/files/live/sites/com-global/files/02%20PDF/Finance/Sodexo-Integrated-Report-Fiscal-2020.pdf,net_zero_tracker
+net_zero_tracker:969500LENY69X51OOT31:2050,969500LENY69X51OOT31,Net zero,,2050,,,https://netzero.veolia.co.uk/our-commitments-and-road-map-uk-and-ireland/,net_zero_tracker
+net_zero_tracker:969500MCOONR8990S771:2040,969500MCOONR8990S771,Net zero,,2040,,,https://www.orange.com/en/environmental-commitment-orange-vows-achieve-net-zero-carbon-emissions-2040,net_zero_tracker
+net_zero_tracker:969500MMPQVHK671GT54:2050,969500MMPQVHK671GT54,Climate neutral,,2050,,,https://www.airliquide.com/sites/airliquide.com/files/2021/03/22/act-leaflet.pdf,net_zero_tracker
+net_zero_tracker:969500P8M3W2XX376054:2030,969500P8M3W2XX376054,Net zero,,2030,,,https://www.covivio.eu/en/wp-content/uploads/sites/3/2021/11/PR-Carbon-trajectory.pdf,net_zero_tracker
+net_zero_tracker:969500PB4U31KEFHZ621:2030,969500PB4U31KEFHZ621,Climate neutral,,2030,,,https://www.klepierre.com/en/finance/2020-universal-registration-document,net_zero_tracker
+net_zero_tracker:969500QZC2Q0TK11NV07:2050,969500QZC2Q0TK11NV07,Net zero,,2050,,,https://all.accor.com/fr/sustainable-development/index.shtml,net_zero_tracker
+net_zero_tracker:969500UIC89GT3UL7L24:2050,969500UIC89GT3UL7L24,Climate neutral,,2050,,,https://ungc-production.s3.us-west-2.amazonaws.com/attachments/cop_2020/487926/original/2019_SAFRAN__Integrated_Report.pdf?1596528297,net_zero_tracker
+net_zero_tracker:969500WP61NBK098AC47:2050,969500WP61NBK098AC47,Climate neutral,,2050,,,https://www.groupeseb.com/en/climate-action,net_zero_tracker
+net_zero_tracker:969500XXRPGD7HCAFA90:2050,969500XXRPGD7HCAFA90,Net zero,,2050,,,https://www.legrandgroup.com/sites/default/files/Documents_PDF_Legrand/Finance/2021/autres/Legrand_URD_2020_1620039999.pdf,net_zero_tracker
+net_zero_tracker:98450079DA0B78DD6764:2050,98450079DA0B78DD6764,Climate neutral,,2050,,,https://www.united.com/ual/en/us/fly/company/global-citizenship/environment.html,net_zero_tracker
+net_zero_tracker:9DJT3UXIJIZJI4WXO774:2050,9DJT3UXIJIZJI4WXO774,Net zero,,2050,,,https://d1io3yog0oux5.cloudfront.net/_0eb62bf63283ad7d1c7167c2f788c416/bankofamerica/db/867/9129/annual_report/BAC_2020_Annual_Report.pdf,net_zero_tracker
+net_zero_tracker:9N3UAJSNOUXFKQLF3V18:2050,9N3UAJSNOUXFKQLF3V18,Net zero,,2050,,,https://pplweb.mediaroom.com/2021-08-05-PPL-Corporation-Reports-Second-Quarter-2021-Earnings-Announces-Net-Zero-Carbon-Emissions-Goal,net_zero_tracker
+net_zero_tracker:AR5L2ODV9HN37376R084:2050,AR5L2ODV9HN37376R084,Net zero,,2050,,,https://www.mastercard.com/news/press/2021/january/mastercard-pledges-net-zero-emissions-innovates-for-collective-climate-action/,net_zero_tracker
+net_zero_tracker:BQ4BKCS1HXDV9HN80Z93:2030,BQ4BKCS1HXDV9HN80Z93,Net zero,,2030,,,https://sustainability.fb.com/wp-content/uploads/2020/07/Sustainability_Report_2019-2.pdf,net_zero_tracker
+net_zero_tracker:BSYCX13Y0NOTV14V9N85:2050,BSYCX13Y0NOTV14V9N85,Net zero,,2050,,,https://www.repsol.com/content/dam/repsol-corporate/en_gb/accionistas-e-inversores/informes-anuales/2021/integrated-management-report-2021.pdf,net_zero_tracker
+net_zero_tracker:BUCRF72VH5RBN7X3VL35:2050,BUCRF72VH5RBN7X3VL35,Net zero,,2050,,,https://www.entergy.com/environment/,net_zero_tracker
+net_zero_tracker:C4BXATY60WC6XEOZDX54:2020,C4BXATY60WC6XEOZDX54,Climate neutral,,2020,,,https://sustainabilityreport.metlife.com/content/dam/metlifecom/us/sustainability/pdf/report/2020/2020-sustainability-report.pdf,net_zero_tracker
+net_zero_tracker:CQ7WZ4NOFWT7FAE6Q943:2023,CQ7WZ4NOFWT7FAE6Q943,Net zero,,2023,,,https://www.fluor.com/sustainability/health-safety-environmental/environment,net_zero_tracker
+net_zero_tracker:CUMYEZJOAF02RYZ1JJ85:2050,CUMYEZJOAF02RYZ1JJ85,Net zero,,2050,,,https://secure02.principal.com/publicvsupply/GetFile?fm=EE12496&ty=VOP,net_zero_tracker
+net_zero_tracker:D01LMJZU09ULLNCY6Z23:2050,D01LMJZU09ULLNCY6Z23,Climate neutral,,2050,,,https://www.edie.net/news/6/UPS-aims-for-carbon-neutral-by-2050/,net_zero_tracker
+net_zero_tracker:D71FAKCBLFS2O0RBPG08:2050,D71FAKCBLFS2O0RBPG08,Net zero,,2050,,,https://investor.williams.com/press-releases/press-release-details/2020/Williams-Announces-Goal-of-56-Absolute-Reduction-in-Greenhouse-Gas-Emissions-by-2030/default.aspx,net_zero_tracker
+net_zero_tracker:DS830JTTZQN6GK0I2E41:2040,DS830JTTZQN6GK0I2E41,Climate neutral,,2040,,,https://www.libertyglobal.com/liberty-global-signs-european-green-digital-declaration/,net_zero_tracker
+net_zero_tracker:DX6GCWD4Q1JO9CRE5I40:2050,DX6GCWD4Q1JO9CRE5I40,Climate neutral,,2050,,,https://ugiesg.com/environment/,net_zero_tracker
+net_zero_tracker:E0JAN6VLUDI1HITHT809:2022,E0JAN6VLUDI1HITHT809,Climate neutral,,2022,,,https://www.chubb.com/content/dam/chubb-sites/chubb-com/us-en/about-chubb/environment/doc/Chubb_2021_Climate-Related_Financial_Disclosure_and_Environmental_Report.pdf,net_zero_tracker
+net_zero_tracker:E26EDV109X6EEPBKVH76:2045,E26EDV109X6EEPBKVH76,Net zero,,2045,,,https://www.centrica.com/stories/2021/our-people-planet-plan/,net_zero_tracker
+net_zero_tracker:ERO1WSFOSR0JJ6CRQ987:2050,ERO1WSFOSR0JJ6CRQ987,Net zero,,2050,,,https://resources.manpowergroup.com/story/working-to-change-the-world-2021/page/5/1,net_zero_tracker
+net_zero_tracker:F5WCUMTUM4RKZ1MAIE39:2050,F5WCUMTUM4RKZ1MAIE39,Net zero,,2050,,,https://www-axa-com.cdn.axa-contento-118412.eu/www-axa-com/7c51bab4-4266-42b6-aa8a-a6b209ee6e33_2019ClimateStrategy.pdf,net_zero_tracker
+net_zero_tracker:F8SB4JFBSYQFRQEH3Z21:2050,F8SB4JFBSYQFRQEH3Z21,Net zero,,2050,,,https://www.nab.com.au/about-us/social-impact/environment/climate-change,net_zero_tracker
+net_zero_tracker:FCNMH6O7VWU7LHXMK351:2050,FCNMH6O7VWU7LHXMK351,Net zero,,2050,,,https://www.cabotcorp.com/-/media/files/reports/responsibility/cabot-corporation-sustainability-report-2021.pdf?la=en&rev=f75baea27ba94c0b8f6cae54ab91f2df,net_zero_tracker
+net_zero_tracker:FDPVHDGJ1IQZFK9KH630:2050,FDPVHDGJ1IQZFK9KH630,Climate neutral,,2050,,,https://www.eastman.com/Company/Sustainability/Documents/Eastman-Sustainability-Report-2020.pdf,net_zero_tracker
+net_zero_tracker:FGLT0EWZSUIRRITFOA30:2045,FGLT0EWZSUIRRITFOA30,Net zero,,2045,,,https://www.emerson.com/documents/corporate/emerson-2021-environmental-social-governance-report-en-us-8186672.pdf,net_zero_tracker
+net_zero_tracker:FJSUNZKFNQ5YPJ5OT455:2040,FJSUNZKFNQ5YPJ5OT455,Net zero,,2040,,,https://www.pepsico.com/our-impact/esg-topics-a-z/climate-change,net_zero_tracker
+net_zero_tracker:FRDRIPF3EKNDJ2CQJL29:2030,FRDRIPF3EKNDJ2CQJL29,Climate neutral,,2030,,,https://www.lilly.com/impact/minimizing-our-environmental-impact,net_zero_tracker
+net_zero_tracker:FRKKVKAIQEF3FCSTPG55:2050,FRKKVKAIQEF3FCSTPG55,Net zero,,2050,,,https://redshift.autodesk.com/net-zero-carbon/,net_zero_tracker
+net_zero_tracker:FXM8FAOHMYDIPD38UZ17:2040,FXM8FAOHMYDIPD38UZ17,Net zero,,2040,,,https://www.bookingholdings.com/wp-content/uploads/2022/03/BKNG-Sustainability-Report-2021.pdf,net_zero_tracker
+net_zero_tracker:FY8JBF7CCL2VE4F1B628:2050,FY8JBF7CCL2VE4F1B628,Net zero,,2050,,,https://investors.pxd.com/news-releases/news-release-details/pioneer-natural-resources-releases-2021-sustainability-report,net_zero_tracker
+net_zero_tracker:GYVOE5EZ4GDAVTU4CQ61:2050,GYVOE5EZ4GDAVTU4CQ61,Net zero,,2050,,,https://www.analog.com/media/en/company-csr/adi-2020-corporate-responsibility-report.pdf,net_zero_tracker
+net_zero_tracker:H1J8DDZKZP6H7RWC0H53:2040,H1J8DDZKZP6H7RWC0H53,Net zero,,2040,,,https://www.qualcomm.com/content/dam/qcomm-martech/dm-assets/documents/2021-qualcomm-corporate-responsibility-report.pdf,net_zero_tracker
+net_zero_tracker:HCHV7422L5HDJZCRFL38:2050,HCHV7422L5HDJZCRFL38,Net zero,,2050,,,https://thermofisher.mediaroom.com/2021-07-27-Thermo-Fisher-Scientific-Commits-to-Achieve-Net-Zero-Carbon-Emissions-by-2050,net_zero_tracker
+net_zero_tracker:HL3H1H2BGXWVG3BSWR90:2030,HL3H1H2BGXWVG3BSWR90,Net zero,,2030,,,https://www.pmi.com/sustainability/our-2025-roadmap,net_zero_tracker
+net_zero_tracker:HL5XPTVRV0O8TUN5LL90:2040,HL5XPTVRV0O8TUN5LL90,Net zero,,2040,,,https://corporate.bestbuy.com/best-buy-signs-the-climate-pledge-accelerating-sustainability-goals/,net_zero_tracker
+net_zero_tracker:HLYYNH7UQUORYSJQCN42:2040,HLYYNH7UQUORYSJQCN42,Climate neutral,,2040,,,https://annual-report.bms.com/assets/bms-ar/documents/2021-annual-report.pdf,net_zero_tracker
+net_zero_tracker:HO1QNWM0IXBZ0QSMMO20:2040,HO1QNWM0IXBZ0QSMMO20,Net zero,,2040,,,https://corporate.ralphlauren.com/on/demandware.static/-/Sites-RalphLauren_Corporate-Library/default/dw7119005d/documents/2022-RL-GCSReport.pdf,net_zero_tracker
+net_zero_tracker:HV5W8PGLJ127N2SFSM23:2030,HV5W8PGLJ127N2SFSM23,Net zero,,2030,,,https://www.bkb.ch/de/-/media/bkb/website/pdf/berichte-und-praesentationen/bkb-strategie-2022plus.pdf,net_zero_tracker
+net_zero_tracker:HWUPKR0MPOU8FGXBT394:2030,HWUPKR0MPOU8FGXBT394,Climate neutral,,2030,,,https://www.apple.com/environment/pdf/Apple_Environmental_Progress_Report_2021.pdf,net_zero_tracker
+net_zero_tracker:I07WOS4YJ0N7YRFE7309:2050,I07WOS4YJ0N7YRFE7309,Net zero,,2050,,,https://investors.rtx.com/static-files/56ac9c22-51b0-43e4-a12e-842f9fdcf3fa,net_zero_tracker
+net_zero_tracker:I1BZKREC126H0VB1BL91:2050,I1BZKREC126H0VB1BL91,Net zero,,2050,,,https://www.duke-energy.com/our-company/esg/esg-report,net_zero_tracker
+net_zero_tracker:ICE2EP6D98PQUILVRZ91:2040,ICE2EP6D98PQUILVRZ91,Climate neutral,,2040,,,https://investors.bd.com/static-files/3cd64f37-762a-4aa7-bd81-9b9030172dee,net_zero_tracker
+net_zero_tracker:IGJSJL3JD5P30I6NJZ34:2050,IGJSJL3JD5P30I6NJZ34,Net zero,,2050,,,https://www.morganstanley.com/ideas/climate-change-net-zero-financed-emissions,net_zero_tracker
+net_zero_tracker:ILUL7B6Z54MRYCF6H308:2050,ILUL7B6Z54MRYCF6H308,Net zero,,2050,,,https://news.dominionenergy.com/2022-02-11-Dominion-Energy-Broadens-Net-Zero-Commitments,net_zero_tracker
+net_zero_tracker:IM7X0T3ECJW4C1T7ON55:2050,IM7X0T3ECJW4C1T7ON55,Net zero,,2050,,,https://www.oxy.com/Sustainability/overview/Documents/ClimateReport2020.pdf,net_zero_tracker
+net_zero_tracker:ISRPG12PN4EIEOEMW547:2035,ISRPG12PN4EIEOEMW547,Climate neutral,,2035,,,https://www.honeywell.com/content/dam/honeywellbt/en/documents/downloads/Hon-Corporate-Citizenship-Report.pdf,net_zero_tracker
+net_zero_tracker:IWUQB36BXD6OWD6X4T14:2050,IWUQB36BXD6OWD6X4T14,Net zero,,2050,,,https://www.aa.com/content/images/customer-service/about-us/corporate-governance/esg/aag-esg-report-2021.pdf,net_zero_tracker
+net_zero_tracker:J3WHBG0MTS7O8ZVMDC91:2050,J3WHBG0MTS7O8ZVMDC91,Net zero,,2050,,,https://corporate.exxonmobil.com/-/media/Global/Files/Advancing-Climate-Solutions-Progress-Report/2022/ExxonMobil-Advancing-Climate-Solutions-2022-Progress-Report.pdf?la=en&hash=AFC42B15F21ADB081F9A35AA685385A3287F48E5,net_zero_tracker
+net_zero_tracker:J48DJYXDTLHM30UMYI18:2050,J48DJYXDTLHM30UMYI18,Net zero,,2050,,,https://www.itochu.co.jp/en/csr/pdf/21fulle-all.pdf,net_zero_tracker
+net_zero_tracker:J5OIVXX3P24RJRW5CK77:2040,J5OIVXX3P24RJRW5CK77,Climate neutral,,2040,,,https://www.baxter.com/sites/g/files/ebysai3896/files/2022-06/Baxter_2021_Corporate_Responsibility_Report.pdf,net_zero_tracker
+net_zero_tracker:JNLUVFYJT1OZSIQ24U47:2050,JNLUVFYJT1OZSIQ24U47,Net zero,,2050,,,https://www.ussteel.com/media/newsroom/-/blogs/united-states-steel-corporation-announces-goal-to-achieve-carbon-neutrality-by-2050,net_zero_tracker
+net_zero_tracker:KNX4USFCNGPY45LOCE31:2040,KNX4USFCNGPY45LOCE31,Net zero,,2040,,,http://csrreportbuilder.intel.com/pdfbuilder/pdfs/CSR-2020-21-Full-Report.pdf,net_zero_tracker
+net_zero_tracker:KVIPTY4PULAPGC1VVD26:2050,KVIPTY4PULAPGC1VVD26,Net zero,,2050,,,https://mitsubishicorp.disclosure.site/en/themes/113#917,net_zero_tracker
+net_zero_tracker:KX1WK48MPD4Y2NCUIZ63:2050,KX1WK48MPD4Y2NCUIZ63,Climate neutral,,2050,,,https://natixis.groupebpce.com/natixis/en/2021-tcfd-report-task-force-on-climate-related-financial-disclosure-lpaz5_133685.html,net_zero_tracker
+net_zero_tracker:KY37LUS27QQX7BB93L28:2050,KY37LUS27QQX7BB93L28,Net zero,,2050,,,https://www.nestle.com/sites/default/files/2022-03/2021-annual-review-en.pdf,net_zero_tracker
+net_zero_tracker:L47NHHI0Z9X22DV46U41:2050,L47NHHI0Z9X22DV46U41,Net zero,,2050,,,https://www.beiersdorf.com/newsroom/press-releases/all-press-releases/2019/12/17-beiersdorf-implements-ambitious-climate-target,net_zero_tracker
+net_zero_tracker:LAXUQCHT4FH58LRZDY46:2050,LAXUQCHT4FH58LRZDY46,Net zero,,2050,,,https://www.eni.com/en-IT/low-carbon/strategy-climate-change.html,net_zero_tracker
+net_zero_tracker:LUZQVYP4VS22CLWDAR65:2050,LUZQVYP4VS22CLWDAR65,Climate neutral,,2050,,,https://multimedia.3m.com/mws/media/2006067O/3m-sustainability-2021-brochure.pdf,net_zero_tracker
+net_zero_tracker:M312WZV08Y7LYUC71685:2040,M312WZV08Y7LYUC71685,Net zero,,2040,,,https://www.swedbank.com/sustainability/environment/climate.html,net_zero_tracker
+net_zero_tracker:MSFSBD3QN1GSN7Q6C537:2050,MSFSBD3QN1GSN7Q6C537,Net zero,,2050,,,https://www.commbank.com.au/content/dam/commbank-assets/about-us/2021-08/2021-annual-report_spreads.pdf#page=12,net_zero_tracker
+net_zero_tracker:MZK1AT00SJV4XB7WNL71:2025,MZK1AT00SJV4XB7WNL71,Climate neutral,,2025,,,https://www.merck.com/wp-content/uploads/sites/5/2021/09/Merck-ESG-Report.pdf,net_zero_tracker
+net_zero_tracker:N8O96ZZJQRFYQUJY7K79:2020,N8O96ZZJQRFYQUJY7K79,Net zero,,2020,,,https://cms-assets.cit.com/9j7wv5nnfw5f/1YzFkTinfizEdYdAzuS0dY/974cee1b0a905fd777dfe5c853a33204/corporate_social_responsibility_report.pdf,net_zero_tracker
+net_zero_tracker:NFONVGN05Z0FMN5PEC35:2050,NFONVGN05Z0FMN5PEC35,Net zero,,2050,,,https://www.saint-gobain.com/sites/saint-gobain.com/files/media/document/2021-06/universal.pdf,net_zero_tracker
+net_zero_tracker:NHBDILHZTYCNBV5UYZ31:2040,NHBDILHZTYCNBV5UYZ31,Net zero,,2040,,,,net_zero_tracker
+net_zero_tracker:NI14Y5UMU60O7JE9P611:2030,NI14Y5UMU60O7JE9P611,Climate neutral,,2030,,,https://www.annualreports.com/HostedData/AnnualReportArchive/a/adecco-group_2019.pdf,net_zero_tracker
+net_zero_tracker:NYLWZIOY8PUNIT4JOE22:2040,NYLWZIOY8PUNIT4JOE22,Net zero,,2040,,,https://www.prnewswire.com/news-releases/crown-elevates-emissions-reduction-initiatives-by-signing-the-climate-pledge-301380743.html,net_zero_tracker
+net_zero_tracker:O2RNE8IBXP4R0TD8PU41:2050,O2RNE8IBXP4R0TD8PU41,Climate neutral,,2050,,,https://www.societegenerale.com/sites/default/files/documents/2021-07/Integrated-Report-2020-2021.pdf,net_zero_tracker
+net_zero_tracker:OC1LZNN2LF5WTJ5RIL89:2030,OC1LZNN2LF5WTJ5RIL89,Net zero,,2030,,,https://www.akamai.com/blog/culture/announcing-akamais-2030-sustainability-goals,net_zero_tracker
+net_zero_tracker:ODVCVCQG2BP6VHV36M30:2050,ODVCVCQG2BP6VHV36M30,Net zero,,2050,,,https://www.aig.com/about-us/sustainability,net_zero_tracker
+net_zero_tracker:OQSJ1DU9TAOC51A47K68:2050,OQSJ1DU9TAOC51A47K68,Net zero,,2050,,,https://stories.starbucks.com/uploads/2022/04/Starbucks-2021-Global-Environmental-and-Social-Impact-Report-1.pdf,net_zero_tracker
+net_zero_tracker:PBBKGKLRK5S5C0Y4T545:2050,PBBKGKLRK5S5C0Y4T545,Net zero,,2050,,,https://www.sempra.com/sites/default/files/content/files/node-report/2020/SempraEnergy_2020_Corporate-Sustainability-Report.pdf,net_zero_tracker
+net_zero_tracker:PBLD0EJDB5FWOLXP3B76:2050,PBLD0EJDB5FWOLXP3B76,Net zero,,2050,,,https://www08.wellsfargomedia.com/assets/pdf/about/corporate-responsibility/environmental-social-governance-report.pdf,net_zero_tracker
+net_zero_tracker:POOXSI30AWAQGYJZC921:2025,POOXSI30AWAQGYJZC921,Climate neutral,,2025,,,https://churchdwight.com/responsibility/environment.aspx,net_zero_tracker
+net_zero_tracker:PUSS41EMO3E6XXNV3U28:2030,PUSS41EMO3E6XXNV3U28,Net zero,,2030,,,https://corporate.pseg.com/-/media/pseg/corporate/corporate-citzenship/environmentalpolicyandinitiatives/sustainability/pseg_sustainability_report.ashx,net_zero_tracker
+net_zero_tracker:Q2CCMS6R0AS67HJMBN42:2050,Q2CCMS6R0AS67HJMBN42,Net zero,,2050,,,https://www.delta.com/content/dam/delta-www/about-delta/corporate-responsibility/2021-esg-report.pdf,net_zero_tracker
+net_zero_tracker:Q9MAIUP40P25UFBFG033:2040,Q9MAIUP40P25UFBFG033,Climate neutral,,2040,,,https://www.eon.com/content/dam/eon/eon-com/eon-com-assets/documents/sustainability/en/climate-related-disclosures/EON_2022_On_course_for_net_zero.pdf,net_zero_tracker
+net_zero_tracker:R0MUWSFPU8MPRO8K5P83:2050,R0MUWSFPU8MPRO8K5P83,Net zero,,2050,,,https://group.bnpparibas/uploads/file/bnp_paribas_2020_integrated_report_en.pdf,net_zero_tracker
+net_zero_tracker:R4PP93JZOLY261QX3811:2035,R4PP93JZOLY261QX3811,Net zero,,2035,,,https://about.americanexpress.com/corporate-responsibility/sustainability/sustainability/default.aspx,net_zero_tracker
+net_zero_tracker:RCGZFPDMRW58VJ54VR07:2021,RCGZFPDMRW58VJ54VR07,Net zero,,2021,,,https://s23.q4cdn.com/574569502/files/doc_governance/2022/Salesforce-ES-Schedules-FY22-EYReport.pdf,net_zero_tracker
+net_zero_tracker:RIFQSET379FOGTEFKS80:2050,RIFQSET379FOGTEFKS80,Net zero,,2050,,,https://www.franklinresources.com/ftresources/investor-relations/annual-report#maintaining-fiscal-responsibility-,net_zero_tracker
+net_zero_tracker:RIMU48P07456QXSO0R61:2035,RIMU48P07456QXSO0R61,Net zero,,2035,,,https://www.northropgrumman.com/wp-content/uploads/2021-NG-Sustainability-Report_Final.pdf,net_zero_tracker
+net_zero_tracker:SJ7XXD41SQU3ZNWUJ746:2030,SJ7XXD41SQU3ZNWUJ746,Net zero,,2030,,,https://www.eversource.com/content/docs/default-source/community/2020-sustainability-report.pdf,net_zero_tracker
+net_zero_tracker:SQ95QG8SR5Q56LSNF682:2050,SQ95QG8SR5Q56LSNF682,Net zero,,2050,,,https://www.illumina.com/content/dam/illumina-marketing/documents/company/illumina-csr-report-2022.pdf,net_zero_tracker
+net_zero_tracker:T2ZG1WRWZ4BUCMQL9224:2050,T2ZG1WRWZ4BUCMQL9224,Climate neutral,,2050,,,https://www.gapinc.com/en-us/values/sustainability/environment/energy-climate,net_zero_tracker
+net_zero_tracker:THRNG6BD57P9QWTQLG42:2020,THRNG6BD57P9QWTQLG42,Climate neutral,,2020,,,https://www.53.com/content/dam/fifth-third/docs/reports/FifthThird-ESG-Report-Final-Environment-ADA.pdf,net_zero_tracker
+net_zero_tracker:THRNG6BD57P9QWTQLG42:2050,THRNG6BD57P9QWTQLG42,Net zero,,2050,,,https://www.bankfab.com/-/media/fabgroup/home/about-fab/sustainability/reports/2021esgreport.pdf?view=1,net_zero_tracker
+net_zero_tracker:TL2N6M87CW970S5SV098:2050,TL2N6M87CW970S5SV098,Climate neutral,,2050,,,https://www.naturgy.com/files/Taxonomia_ENG.pdf,net_zero_tracker
+net_zero_tracker:TSI2PJM6EPETEQ4X1U25:2030,TSI2PJM6EPETEQ4X1U25,Climate neutral,,2030,,,https://www.infineon.com/dgdl/Sustainability+at+Infineon+Supplementing+the+Annual+Report+2021.pdf?fileId=8ac78c8b7d507352017d6b57a9f6016c,net_zero_tracker
+net_zero_tracker:TWSEY0NEDUDCKS27AH81:2050,TWSEY0NEDUDCKS27AH81,Net zero,,2050,,,http://www.pinnaclewest.com/corporate-responsibility/default.aspx,net_zero_tracker
+net_zero_tracker:U4LOSYZ7YG4W3S5F2G91:2030,U4LOSYZ7YG4W3S5F2G91,Net zero,,2030,,,https://www.sc.com/en/sustainability/position-statements/climate-change/,net_zero_tracker
+net_zero_tracker:UDTZ87G0STFETI6HGH41:2050,UDTZ87G0STFETI6HGH41,Climate neutral,,2050,,,https://www.prnewswire.com/news-releases/southwest-airlines-announces-10-year-environmental-sustainability-plan-301402670.html,net_zero_tracker
+net_zero_tracker:UE2136O97NLB5BYP9H04:2050,UE2136O97NLB5BYP9H04,Net zero,,2050,,,https://corporate.mcdonalds.com/content/dam/gwscorp/assets/our-planet/climate-action/McDonalds-2021-Climate-Risk-and-Resiliency-Summary.pdf,net_zero_tracker
+net_zero_tracker:UWJKFUJFZ02DKWI3RY53:2050,UWJKFUJFZ02DKWI3RY53,Net zero,,2050,,,https://www.coca-colacompany.com/content/dam/journey/us/en/reports/coca-cola-business-environmental-social-governance-report-2021.pdf,net_zero_tracker
+net_zero_tracker:V167QI9I69W364E2DY52:2040,V167QI9I69W364E2DY52,Net zero,,2040,,,https://www.tjx.com/responsibility/environment/climate-and-energy,net_zero_tracker
+net_zero_tracker:V82KK8NH1P0JS71FJC05:2050,V82KK8NH1P0JS71FJC05,Climate neutral,,2050,,,https://www.sumitomocorp.com/en/jp/sustainability/environmental-management/climate,net_zero_tracker
+net_zero_tracker:VGRQXHF3J8VDLUA7XE92:2030,VGRQXHF3J8VDLUA7XE92,Net zero,,2030,,,https://www.ibm.com/ibm/environment/annual/IBMEnvReport_2020.pdf,net_zero_tracker
+net_zero_tracker:VH3R4HHBHH12O0EXZJ88:2030,VH3R4HHBHH12O0EXZJ88,Climate neutral,,2030,,,https://literature.rockwellautomation.com/idc/groups/literature/documents/br/esap-br031_-en-p.pdf,net_zero_tracker
+net_zero_tracker:W38RGI023J3WT1HWRP32:2030,W38RGI023J3WT1HWRP32,Net zero,,2030,,,https://assets.new.siemens.com/siemens/assets/api/uuid:4806da09-01c7-40b1-af91-99af4b726653/sustainability2021-en.pdf,net_zero_tracker
+net_zero_tracker:W8J5WZB5IY3K0NDQT671:2050,W8J5WZB5IY3K0NDQT671,Net zero,,2050,,,https://www.biogen.com/en_us/healthy-climate-healthy-lives.html,net_zero_tracker
+net_zero_tracker:WD6L6041MNRW1JE49D58:2050,WD6L6041MNRW1JE49D58,Net zero,,2050,,,https://www.tysonfoods.com/news/news-releases/2021/6/tyson-foods-targets-2050-achieve-net-zero-greenhouse-gas-emissions,net_zero_tracker
+net_zero_tracker:WFLLPEPC7FZXENRZV188:2025,WFLLPEPC7FZXENRZV188,Climate neutral,,2025,,,https://www.bnymellon.com/content/dam/bnymellon/documents/pdf/2020-enterprise-esg-report.pdf.coredownload.pdf,net_zero_tracker
+net_zero_tracker:WHENKOULSSK7WUM60H03:2030,WHENKOULSSK7WUM60H03,Net zero,,2030,,,https://whirlpoolcorp.com/2021SustainabilityReport/downloads/whirlpool_2021_sr.pdf,net_zero_tracker
+net_zero_tracker:WOCMU6HCI0OJWNPRZS33:2040,WOCMU6HCI0OJWNPRZS33,Climate neutral,,2040,,,https://influencemap.org/company/JX-Holdings-8265ac9d61c07ebb304baaf892acac65,net_zero_tracker
+net_zero_tracker:WPTL2Z3FIYTHSP5V2253:2050,WPTL2Z3FIYTHSP5V2253,Net zero,,2050,,,https://www.conocophillips.com/sustainability/managing-climate-related-risks/metrics-targets/ghg-target/,net_zero_tracker
+net_zero_tracker:X2MT1W32SPAZ9WSKLE78:2035,X2MT1W32SPAZ9WSKLE78,Net zero,,2035,,,http://investors.chk.com/2021-07-14-Chesapeake-Energy-Corporation-Announces-New-Collaboration-With-MiQ-And-Equitable-Origin-To-Provide-Independent-Certification-Of-Its-Natural-Gas-Production-In-Two-Major-U-S-Shale-Basins,net_zero_tracker
+net_zero_tracker:XRZQ5S7HYJFPHJ78L959:2050,XRZQ5S7HYJFPHJ78L959,Net zero,,2050,,,https://ameren.mediaroom.com/2020-09-28-Ameren-establishes-net-zero-carbon-emissions-goal-and-a-transformative-expansion-of-wind-and-solar-energy,net_zero_tracker
+net_zero_tracker:XSGZFLO9YTNO9VCQV219:2050,XSGZFLO9YTNO9VCQV219,Net zero,,2050,,,https://www.altria.com/en/responsibility/protect-the-environment,net_zero_tracker
+net_zero_tracker:XWTZDRYZPBUHIQBKDB46:2050,XWTZDRYZPBUHIQBKDB46,Net zero,,2050,,,https://www.equinor.com/content/dam/statoil/documents/climate-and-sustainability/climate-ambition-overview-cmu2022-equinor.pdf,net_zero_tracker
+net_zero_tracker:XWTZDRYZPBUHIQBKDB46:2040,XWTZDRYZPBUHIQBKDB46,Net zero,,2040,,,https://www.eogresources.com/sustainability/,net_zero_tracker
+net_zero_tracker:Y6X4K52KMJMZE7I7MY94:2040,Y6X4K52KMJMZE7I7MY94,Net zero,,2040,,,https://www.spglobal.com/esg/insights/the-journey-to-net-zero-at-sp-global,net_zero_tracker
+net_zero_tracker:Y6ZDD9FP4P8JSSJMW954:2030,Y6ZDD9FP4P8JSSJMW954,Climate neutral,,2030,,,https://www.bostonscientific.com/en-EU/about-us/corporate-social-responsibility/planet/climate-change.html,net_zero_tracker
+net_zero_tracker:Y87794H0US1R65VBXU25:2040,Y87794H0US1R65VBXU25,Net zero,,2040,,,https://corporate.walmart.com/esgreport/esg-issues/climate-change,net_zero_tracker
+net_zero_tracker:YEH5ZCD6E441RHVHD759:2050,YEH5ZCD6E441RHVHD759,Net zero,,2050,,,https://www.bmwgroup.com/content/dam/grpw/websites/bmwgroup_com/ir/downloads/en/2022/bericht/BMW-Group-Report-2021-en.pdf,net_zero_tracker
+net_zero_tracker:YMEGZFW4SBUSS5BQXF88:2040,YMEGZFW4SBUSS5BQXF88,Net zero,,2040,,,https://www.colgatepalmolive.com/content/dam/cp-sites/corporate/corporate/common/pdf/sustainability/colgate-palmolive-sustainability-and-social-impact-final-report-2021.pdf,net_zero_tracker
+net_zero_tracker:ZUNI8PYC725B6H8JU438:2050,ZUNI8PYC725B6H8JU438,Climate neutral,,2050,,,https://www.cummins.com/sites/default/files/2021-05/cummins-tcfd-report-05-19-2021.pdf,net_zero_tracker
+net_zero_tracker:ZXTILKJKG63JELOEG630:2040,ZXTILKJKG63JELOEG630,Net zero,,2040,,,https://sustainability.aboutamazon.com/2021-sustainability-report.pdf,net_zero_tracker

--- a/harmonize/scripts/process_net_zero_tracker.py
+++ b/harmonize/scripts/process_net_zero_tracker.py
@@ -836,6 +836,10 @@ if __name__ == "__main__":
     # merge dataframes
     df_target = pd.concat(dataframe_list+net_zero_list)
 
+    # fill nan URL with blank string
+    df_target['URL'] = df_target['URL'].fillna('')
+    df_target.loc[df_target['URL'] == 'nan', 'URL'] = ''
+
     # shorten long URLs (could be streamliend by not scanning entire file)
     filt = df_target['URL'].fillna('').str.len() > 250
     df_target.loc[filt, 'URL'] = df_target.loc[filt, 'URL'].apply(shorten_url)


### PR DESCRIPTION
Added net zero and adjacent targets from Net Zero Tracker. For `target_type` I went with:
-  "Net zero"
-  "Climate neutral"
- "GHG neutral"

 For these types, `target_year` is the pledged year to achieve this action. I left other fields blank since they don't make sense for this kind of target.