### PR TITLE
feat: add EnergyConsumption and EnergyConsumptionBreakdown tables

### DIFF
--- a/api/schema/SQL/EnergyConsumption.sql
+++ b/api/schema/SQL/EnergyConsumption.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "EnergyConsumption" (
+  "energy_id" varchar(255), /* Energy identifier <source>:<actor_id>:<year> */
+  "actor_id" varchar(255), /* Actor ID for the territory */
+  "year" int, /* Year of measurement, YYYY */
+  "energy_consumption" bigint, /* Energy consumption in megajoules (MJ) */
+  "created" timestamp,
+  "last_updated" timestamp,
+  "datasource_id" varchar(255),
+  PRIMARY KEY ("energy_id"),
+  CONSTRAINT "FK_EnergyConsumption.actor_id"
+    FOREIGN KEY ("actor_id")
+      REFERENCES "Actor"("actor_id"),
+);

--- a/api/schema/SQL/EnergyConsumptionBreakdown.sql
+++ b/api/schema/SQL/EnergyConsumptionBreakdown.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "EnergyConsumptionBreakdown" (
+  "energy_id" varchar(255), /* Energy identifier <source>:<actor_id>:<year> */
+  "actor_id" varchar(255), /* Actor identifier */
+  "year" int, /* Year of measurement, YYYY */
+  "energy_consumption" bigint, /* Energy consumption in megajoules (MJ) */
+  "fuel_type" varchar(255), /* oil, natural gal, coal, nuclear, hydroelectric, renewable */
+  "created" timestamp,
+  "last_updated" timestamp,
+  PRIMARY KEY ("energy_id", "fuel_type"),
+  CONSTRAINT "FK_EnergyConsumptionBreakdown.energy_id"
+    FOREIGN KEY ("energy_id")
+      REFERENCES "EnergyConsumption"("energy_id"),
+  CONSTRAINT "FK_EnergyConsumptionBreakdown.actor_id"
+    FOREIGN KEY ("actor_id")
+      REFERENCES "Actor"("actor_id"),
+);


### PR DESCRIPTION
adds 2 new tables to the schema:
- `EnergyConsumption` - this is the total annual energy consumption in megajoules (MJ) for an actor
- `EnergyConsumptionBreakdown` - this is a breakdown of the total annual energy consumption into consumption by different fuel types (coal, oil, renewables, ...)