### PR TITLE
Allow hovering over trends widget points to see their data

### DIFF
--- a/ui/src/components/review/level-cards.tsx
+++ b/ui/src/components/review/level-cards.tsx
@@ -7,6 +7,7 @@ import IndicatorCard from "./indicator-card";
 import { useMatomo } from "@jonkoops/matomo-tracker-react";
 import { MdArrowBack } from "react-icons/md";
 import { HiOutlineSearch } from "react-icons/hi";
+import { ServerUrls } from "../../shared/environments/server.environments";
 
 interface IProps {
   selectFilter: (filterType: FilterTypes, option: DropdownOption) => void;
@@ -133,7 +134,7 @@ const LevelCards: FunctionComponent<IProps> = (props) => {
   const getOptions = async (actor_id: string, type: string) => {
     const recursive = type == "city" || type == "site" ? "yes" : "no";
     const res = await fetch(
-      `/api/v1/actor/${actor_id}/parts?type=${type}&recursive=${recursive}`
+      `${ServerUrls.api}/v1/actor/${actor_id}/parts?type=${type}&recursive=${recursive}`
     );
     const json = await res.json();
 

--- a/ui/src/components/review/review.page.tsx
+++ b/ui/src/components/review/review.page.tsx
@@ -14,6 +14,7 @@ import CollaborationCardHint from "./CollaborateCardHint";
 import ActorFlag from "./actor-flag/actor-flag";
 import { Helmet } from "react-helmet";
 import { useMatomo } from "@jonkoops/matomo-tracker-react"; 
+import { ServerUrls } from "../../shared/environments/server.environments";
 
 type ReviewPageParams = {
   actorID: string;
@@ -66,7 +67,7 @@ const ReviewPage: FunctionComponent = () => {
   }, [actors, current]);
 
   const insertActor = (actorID: any, children: Array<any>) => {
-    fetch(`/api/v1/actor/${actorID}`)
+    fetch(`${ServerUrls.api}/v1/actor/${actorID}`)
       .then((res) => res.json())
       .then((json) => json.data)
       .then((actor) => {

--- a/ui/src/components/review/trends-widget/TrendsWidget.module.scss
+++ b/ui/src/components/review/trends-widget/TrendsWidget.module.scss
@@ -398,7 +398,6 @@
     grid-column: 2;
     grid-template-columns: auto auto;
     row-gap: 5px;
-    height: 80px;
     overflow: hidden;
 }
 

--- a/ui/src/components/review/trends-widget/TrendsWidget.tsx
+++ b/ui/src/components/review/trends-widget/TrendsWidget.tsx
@@ -140,10 +140,12 @@ const TrendsWidget:FC<TrendsWidgetProps> = (props) => {
         setSelectedSources(sources)
     }
 
+    const [hoveredLineSource, setHoveredLineSource] = useState('');
     const lines = selectedSources.map((source) => (
         <Line
             type="monotone"
             dataKey={`emissions.${source}.total_emissions`}
+            onMouseOver={() => setHoveredLineSource(source)}
             key={source}
             fill="#fa7200"
             stroke="#fa7200"
@@ -163,15 +165,20 @@ const TrendsWidget:FC<TrendsWidgetProps> = (props) => {
     );
 
     interface TooltipProps {
-        active: boolean
-        payload: []
-        label: string
+        active: boolean;
+        payload: [];
+        label: string;
     }
 
     const ToolTipContent:FC<TooltipProps> = ({active, payload, label}) => {
         if(active && payload && payload.length){
+            let payloadIndex = 0;
+            if (hoveredLineSource !== '') {
+                payloadIndex = payload.findIndex((entry) => entry.dataKey.split('.')[1] === hoveredLineSource);
+            }
+            const payloadData = payload[payloadIndex];
 
-            let src = payload[0].dataKey.split(".")
+            let src = payloadData.dataKey.split(".")
             src = src[1]
 
             let modifiedSrc = null
@@ -183,9 +190,9 @@ const TrendsWidget:FC<TrendsWidgetProps> = (props) => {
             let tags = null
 
             if(src){
-                tags = payload[0].payload.emissions[src].tags
+                tags = payloadData.payload.emissions[src].tags
             }else{
-                tags = payload[0].payload.emissions.tags
+                tags = payloadData.payload.emissions.tags
             }
 
           return(
@@ -195,7 +202,7 @@ const TrendsWidget:FC<TrendsWidgetProps> = (props) => {
                 </div>
                 <div className={style.tooltipBody}>
                     <div className={style.emissionsData}>
-                        <p className={style.ttlEmsValue}>{readableEmissions(payload[0].value)}</p>
+                        <p className={style.ttlEmsValue}>{readableEmissions(payloadData.value)}</p>
                         <p className={style.ttlEmsText}>Total emissions in GtCO2eq</p>
                     </div>
                     <div className={style.sourceData}>

--- a/ui/src/components/review/trends-widget/TrendsWidget.tsx
+++ b/ui/src/components/review/trends-widget/TrendsWidget.tsx
@@ -145,7 +145,7 @@ const TrendsWidget:FC<TrendsWidgetProps> = (props) => {
         <Line
             type="monotone"
             dataKey={`emissions.${source}.total_emissions`}
-            onMouseOver={() => setHoveredLineSource(source)}
+            onMouseMove={() => setHoveredLineSource(source)}
             key={source}
             fill="#fa7200"
             stroke="#fa7200"

--- a/ui/src/shared/helpers/country-codes.helper.ts
+++ b/ui/src/shared/helpers/country-codes.helper.ts
@@ -1,9 +1,10 @@
 import countryCodesJson from "../../api/data/review/data/country-codes";
 import ICountry from "../../api/models/review/country";
 import { regions } from "../../api/data/review/data/regions";
+import { ServerUrls } from "../../shared/environments/server.environments";
 
 const GetCountryCodes = async () => {
-  let countryParsed = await fetch("/api/v1/actor/EARTH/parts", {
+  let countryParsed = await fetch(`${ServerUrls.api}/v1/actor/EARTH/parts`, {
     method: "GET",
   });
   const jsonData = await countryParsed.json();
@@ -48,7 +49,7 @@ const GetCountryOptionsForSite = async () => {
 };
 
 const GetSubnationalsByCountryCode = async (actor_id: number) => {
-  const res = await fetch(`/api/v1/actor/${actor_id}/parts`, {
+  const res = await fetch(`${ServerUrls.api}/v1/actor/${actor_id}/parts`, {
     method: "GET",
   });
 
@@ -65,7 +66,7 @@ const GetSubnationalsByCountryCode = async (actor_id: number) => {
 };
 
 const GetCitiesBySubnationalId = async (actor_id: number) => {
-  const res = await fetch(`/api/v1/actor/${actor_id}/parts`, {
+  const res = await fetch(`${ServerUrls.api}/v1/actor/${actor_id}/parts`, {
     method: "GET",
   });
 


### PR DESCRIPTION
- Add hover listener for TrendsWidget lines and use it to adjust state
- Show data from the appropriate source in tooltip when it is hovered
- Allow configuring ServerUrls.api more easily by using it in all places where custom API requests are made

It's not quite perfect as Recharts doesn't call any of the events listeners when you move the mouse cursor up and down on the same X coordinate, so you have to move left and then to the other point you want to look at to make the tooltip update. Not sure if this can be fixed without patching Recharts or creating custom DOM-level listeners for the lines though...